### PR TITLE
Allow scrolling to fixed position while message streams

### DIFF
--- a/src/renderer/components/Message.tsx
+++ b/src/renderer/components/Message.tsx
@@ -98,7 +98,7 @@ export default function Message(props: Props) {
 
     useEffect(() => {
         if (msg.generating) {
-            scrollActions.scrollToBottom()
+            scrollActions.scrollToBottom(false)
         }
     }, [msg.content])
 

--- a/src/renderer/stores/scrollActions.ts
+++ b/src/renderer/stores/scrollActions.ts
@@ -1,13 +1,20 @@
 import { getDefaultStore } from 'jotai'
 import * as atoms from './atoms'
 
-export function scrollToBottom(behavior: 'auto' | 'smooth' = 'auto') {
+export function scrollToBottom(force: boolean, behavior: 'auto' | 'smooth' = 'auto') {
+    console.log('called scrollToBottom with', force)
     const store = getDefaultStore()
     const messageListRef = store.get(atoms.messageListRefAtom)
     if (messageListRef && messageListRef.current) {
-        messageListRef.current.scrollTo({
-            top: messageListRef.current.scrollHeight,
-            behavior,
-        })
+        const scrollTop = messageListRef.current.scrollTop;
+        const scrollHeight = messageListRef.current.scrollHeight;
+        const clientHeight = messageListRef.current.clientHeight;
+        const bottomOffset = scrollHeight - scrollTop - clientHeight;
+        if (bottomOffset <= 250 || force) {
+            messageListRef.current.scrollTo({
+                top: scrollHeight,
+                behavior,
+            })
+        }
     }
 }

--- a/src/renderer/stores/sessionActions.ts
+++ b/src/renderer/stores/sessionActions.ts
@@ -60,7 +60,7 @@ export function createEmpty(type: 'chat') {
 export function switchCurrentSession(sessionId: string) {
     const store = getDefaultStore()
     store.set(atoms.currentSessionIdAtom, sessionId)
-    scrollActions.scrollToBottom()
+    scrollActions.scrollToBottom(true)
 }
 
 export function remove(session: Session) {


### PR DESCRIPTION
- **Current:** When message is streaming back to the client, the message window continuously scrolls to the bottom. This is a nice effect but it prevents the user from scrolling up to the beginning of the response and start reading immediately while the rest keeps streaming. Instead, the user has to wait until the message has finished streaming and then scroll up.
- **In this PR:** The message scrolls to the bottom only if the position is already within 250 px from the bottom. This way, if let alone the message will keep display and scroll as usual. If instead the user scrolls up to get to the beginning, the scrolling stops and allows for comfortable reading while the rest of the message streams back and is appended to the bottom outside of the view.