### PR TITLE
fix: correct engines field to prevent npm install error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,10 @@
                 "webpack-cli": "^5.1.1",
                 "webpack-dev-server": "^4.15.0",
                 "webpack-merge": "^5.9.0"
+            },
+            "engines": {
+                "node": ">=14.x",
+                "npm": ">=7.x"
             }
         },
         "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -285,7 +285,7 @@
             }
         ]
     },
-    "devEngines": {
+    "engines": {
         "node": ">=14.x",
         "npm": ">=7.x"
     },


### PR DESCRIPTION
### Description

The "devEngines" field is not a valid npm field, causing an "Invalid property 'node'" error during installation. Replaced it with "engines" to correctly specify Node.js and npm version requirements.


### Additional Notes

Solving #1798

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

Please check the box below to confirm:

[x] I have read and agree with the above statement.
