### PR TITLE
Fix/generate title problem

### DIFF
--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -5,6 +5,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import * as sessionActions from '../stores/sessionActions'
 import Toolbar from './Toolbar'
 import { cn } from '@/lib/utils'
+import { getAutoGenerateTitle } from '@/stores/settingActions'
 
 interface Props { }
 
@@ -14,7 +15,9 @@ export default function Header(props: Props) {
     const setChatConfigDialogSession = useSetAtom(atoms.chatConfigDialogAtom)
 
     useEffect(() => {
+        const autoGenerateTitle : boolean = getAutoGenerateTitle()
         if (
+            autoGenerateTitle &&
             currentSession.name === 'Untitled'
             && currentSession.messages.length >= 2
         ) {

--- a/src/renderer/stores/sessionActions.ts
+++ b/src/renderer/stores/sessionActions.ts
@@ -17,7 +17,6 @@ import platform from '../packages/platform'
 import { throttle } from 'lodash'
 import { countWord } from '@/packages/word-count'
 import { estimateTokensFromMessages } from '@/packages/token'
-import * as settingActions from './settingActions'
 
 export function create(newSession: Session) {
     const store = getDefaultStore()
@@ -175,10 +174,7 @@ export async function generate(sessionId: string, targetMsg: Message) {
     if (!session) {
         return
     }
-    const autoGenerateTitle = settingActions.getAutoGenerateTitle()
-    if (!autoGenerateTitle) {
-        return
-    }
+    
     const placeholder = '...'
     targetMsg = {
         ...targetMsg,


### PR DESCRIPTION
### Description

"AutoGenerateTitle" setting doesnt set up properly. Instead of blocking Title generation logic, it actually blocks chat. Removed it from chat, added it to generate title effect.

### Screenshots

#### Before

Auto Generate Title: Off
![image](https://github.com/user-attachments/assets/3b1edf5c-bfdd-4f14-9769-ec2c9bfd0e23)

Auto Generate Title: On
![image](https://github.com/user-attachments/assets/b44fb03c-39de-457d-836a-9ea0a589d35b)

#### After
Fixed it but I dont have any screenshots of it. Its an easy fix anyway.

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

Please check the box below to confirm:

[ X ] I have read and agree with the above statement.
