### PR TITLE
feature/Add toggleable thought box to assistant messages

### DIFF
--- a/src/renderer/components/Message.tsx
+++ b/src/renderer/components/Message.tsx
@@ -9,6 +9,8 @@ import {
 import PersonIcon from '@mui/icons-material/Person'
 import SmartToyIcon from '@mui/icons-material/SmartToy'
 import SettingsIcon from '@mui/icons-material/Settings'
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { useTranslation } from 'react-i18next'
 import { Message, SessionType } from '../../shared/types'
 import { useAtomValue, useSetAtom } from 'jotai'
@@ -60,6 +62,7 @@ export default function Message(props: Props) {
         && (JSON.stringify(msg.content)).length > collapseThreshold
         && (JSON.stringify(msg.content)).length - collapseThreshold > 50
     const [isCollapsed, setIsCollapsed] = useState(needCollapse)
+    const [isThoughtsCollapsed, setIsThoughtsCollapsed] = useState(true)
 
     const ref = useRef<HTMLDivElement>(null)
 
@@ -109,6 +112,16 @@ export default function Message(props: Props) {
     if (msg.generating) {
         content += '...'
     }
+
+    let thinkingPart = ''
+    if (msg.role === 'assistant') {
+        const thinkMatches = content.match(/<thinking>(.*?)<\/thinking>/s)
+        if (thinkMatches) {
+            thinkingPart = thinkMatches[1].trim()
+            content = content.replace(thinkMatches[0], '').trim()
+        }
+    }
+
     if (needCollapse && isCollapsed) {
         content = msg.content.slice(0, collapseThreshold) + '... '
     }
@@ -203,6 +216,21 @@ export default function Message(props: Props) {
                         <Box className={cn('msg-content', { 'msg-content-small': small })} sx={
                             small ? { fontSize: theme.typography.body2.fontSize } : {}
                         }>
+                            {
+                                thinkingPart && ( 
+                                    <>
+                                        <Typography variant="body2" sx={{ opacity: 0.5 }}>
+                                            <span className='cursor-pointer flex items-center gap-1' onClick={() => setIsThoughtsCollapsed(!isThoughtsCollapsed)}>
+                                                {"Thoughts"}
+                                                {isThoughtsCollapsed ? <KeyboardArrowDownIcon/> : <KeyboardArrowUpIcon/>}
+                                            </span>
+                                        </Typography>
+                                        <Typography variant="body2" sx={{ opacity: 0.8 }} className={isThoughtsCollapsed ? 'hidden' : ''}>
+                                            {thinkingPart}
+                                        </Typography>
+                                    </>
+                                )
+                            }
                             {
                                 enableMarkdownRendering && !isCollapsed ? (
                                     <Markdown>


### PR DESCRIPTION
### Description

Now that some AI's such as deepseek send their thinking processes inside a "thinking" element, I added a toggleable box to show/hide them.

### Additional Notes

[If you have any additional comments or notes, please add them here]

### Screenshots

![image](https://github.com/user-attachments/assets/2d0509a7-d0e5-4cbf-a23a-202216043a17)

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

Please check the box below to confirm:

[ X  ] I have read and agree with the above statement.
