### PR TITLE
feature/Add support for multiple responses from AI assistant

### DIFF
--- a/src/renderer/components/Message.tsx
+++ b/src/renderer/components/Message.tsx
@@ -65,7 +65,7 @@ export default function Message(props: Props) {
 
     const tips: string[] = []
     if (props.sessionType === 'chat' || !props.sessionType) {
-        if (showWordCount && !msg.generating) {
+        if (showWordCount && !msg.generating && msg.role != 'system') {
             tips.push(`word count: ${msg.wordCount !== undefined ? msg.wordCount : countWord(msg.content)}`)
         }
         if (showTokenCount && !msg.generating) {
@@ -135,8 +135,8 @@ export default function Message(props: Props) {
                 {
                     user: 'user-msg',
                     system: 'system-msg',
-                    assistant: 'assistant-msg',
-                }[msg?.role || 'user'],
+                    assistant: 'assistant-msg'
+                }[msg?.role === 'unknown' ? 'assistant' : msg.role],
                 className,
             )}
             sx={{
@@ -194,7 +194,7 @@ export default function Message(props: Props) {
                                         >
                                             <SettingsIcon fontSize='small' />
                                         </Avatar>
-                            }[msg.role]
+                            }[msg.role === 'unknown' ? 'assistant' : msg.role]
                         }
                     </Box>
                 </Grid>

--- a/src/renderer/packages/models/base.ts
+++ b/src/renderer/packages/models/base.ts
@@ -18,7 +18,7 @@ export default class Base {
         return await this._chat(messages, onResultUpdated)
     }
 
-    protected async _chat(messages: Message[], onResultUpdated?: (data: { text: string, cancel(): void }) => void): Promise<string> {
+    protected async _chat(messages: Message[], onResultUpdated?: (data: { text: string, role?: string, cancel(): void }) => void): Promise<string> {
         let canceled = false
         const controller = new AbortController()
         const stop = () => {
@@ -30,9 +30,9 @@ export default class Base {
             let onResultChange: onResultChange | undefined = undefined
             if (onResultUpdated) {
                 onResultUpdated({ text: result, cancel: stop })
-                onResultChange = (newResult: string) => {
+                onResultChange = (newResult: string, role?: string) => {
                     result = newResult
-                    onResultUpdated({ text: result, cancel: stop })
+                    onResultUpdated({ text: result, role: role, cancel: stop })
                 }
             }
             result = await this.callChatCompletion(messages, controller.signal, onResultChange)
@@ -186,4 +186,4 @@ export default class Base {
     }
 }
 
-export type onResultChange = (result: string) => void
+export type onResultChange = (result: string, role?: string) => void

--- a/src/renderer/packages/models/ollama.ts
+++ b/src/renderer/packages/models/ollama.ts
@@ -1,3 +1,4 @@
+
 import { Message } from 'src/shared/types'
 import Base, { onResultChange } from './base'
 import { ApiError } from './errors'
@@ -50,6 +51,7 @@ export default class Ollama extends Base {
             signal,
         )
         let result = ''
+        let role = 'unknown'
         await this.handleNdjson(res, (message) => {
             const data = JSON.parse(message)
             if (data['done']) {
@@ -59,9 +61,19 @@ export default class Ollama extends Base {
             if (! word) {
                 throw new ApiError(JSON.stringify(data))
             }
+
+            const messageRole = data['message']?.['role'];
+
+            if (role === 'unknown') {
+                role = messageRole;
+            } else if (role !== messageRole) {
+                role = messageRole;
+                result = '';
+            }
+
             result += word
             if (onResultChange) {
-                onResultChange(result)
+                onResultChange(result, messageRole)
             }
         })
         return result

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,6 +7,7 @@ export const MessageRoleEnum = {
     System: 'system',
     User: 'user',
     Assistant: 'assistant',
+    Unknown: "unknown"
 } as const
 
 export type MessageRole = (typeof MessageRoleEnum)[keyof typeof MessageRoleEnum]


### PR DESCRIPTION
## Caution!

### Description

In my local custom AI assistant, my assistant can send me multiple responses as different roles.

When assistant requires extra information from system, assistant runs a custom command. Which then system responds with result. Then assistant completes its response using that result. Thus, giving my assistant the ability to perform multiple step operations.  So I tweaked things a bit, now chatbox supports it.

### Additional Notes

It's a bit of a big PR, so it may break something. I'm especially not sure about models other than deepseek.

### Screenshots

![image](https://github.com/user-attachments/assets/484b70fc-f829-4f4c-91ad-20733ff9993e)


### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

Please check the box below to confirm:

[ X ] I have read and agree with the above statement.
