### PR TITLE
fix: modify version of tailwindcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "sass": "^1.62.1",
         "sass-loader": "^13.3.1",
         "style-loader": "^3.3.3",
-        "tailwindcss": "^4.0.0",
+        "tailwindcss": "^3.4.0",
         "terser-webpack-plugin": "^5.3.9",
         "ts-jest": "^29.1.0",
         "ts-loader": "^9.4.3",


### PR DESCRIPTION
### Description

[When I follow the installation instructions in the README, I encounter an error: "Loading PostCSS 'tailwindcss/nesting' plugin failed: Package subpath './nesting' is not defined by 'exports' in". ]

### Additional Notes

[I have tried multiple versions of Node.js, including "18.20.7" and "20.18.0", but I encounter errors in both cases]

### Screenshots

[
![pr1](https://github.com/user-attachments/assets/55c50a69-3b45-40e1-a025-0679ff73ae9d)
![pr2](https://github.com/user-attachments/assets/9240a12c-fde7-4b5a-8640-de0759b3fb77)
]

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

Please check the box below to confirm:

[+] I have read and agree with the above statement.
