### PR TITLE
fix: auto-scroll to bottom when AI is generating long messages

### DIFF
--- a/src/renderer/components/MessageList.tsx
+++ b/src/renderer/components/MessageList.tsx
@@ -80,6 +80,7 @@ export default function MessageList(props: { className?: string; currentSession:
             setAtBottom(atBottom)
           }}
           ref={virtuoso}
+          followOutput={true}
           {...(sessionScrollPositionCache.has(currentSession.id)
             ? {
                 restoreStateFrom: sessionScrollPositionCache.get(currentSession.id),


### PR DESCRIPTION
### Description

related issue: #2277 

auto-scroll to bottom when AI is generating long messages

### Additional Notes



### Screenshots

![output](https://github.com/user-attachments/assets/374f1479-f299-4956-a172-385a65edbd3b)



### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[ ] I have read and agree with the above statement.
