### PR TITLE
Feature/consistent thread naming

### DIFF
--- a/src/renderer/stores/sessionActions.ts
+++ b/src/renderer/stores/sessionActions.ts
@@ -326,7 +326,7 @@ export function moveThreadToConversations(sessionId: string, threadId: string) {
     ...session,
     name: targetThread.name,
     messages: targetThread.messages,
-    threads: undefined,
+    threads: [],
     threadName: undefined,
   })
   removeThread(sessionId, threadId)
@@ -342,7 +342,7 @@ export function moveCurrentThreadToConversations(sessionId: string) {
     ...session,
     name: session.threadName || session.name,
     messages: session.messages,
-    threads: undefined,
+    threads: [],
     threadName: undefined,
   })
   removeCurrentThread(sessionId)

--- a/src/renderer/stores/sessionActions.ts
+++ b/src/renderer/stores/sessionActions.ts
@@ -324,6 +324,7 @@ export function moveThreadToConversations(sessionId: string, threadId: string) {
   }
   const newSession = copySession({
     ...session,
+    name: targetThread.name,
     messages: targetThread.messages,
     threads: undefined,
     threadName: undefined,
@@ -339,6 +340,7 @@ export function moveCurrentThreadToConversations(sessionId: string) {
   }
   const newSession = copySession({
     ...session,
+    name: session.threadName || session.name,
     messages: session.messages,
     threads: undefined,
     threadName: undefined,

--- a/src/renderer/stores/sessionStorageMutations.ts
+++ b/src/renderer/stores/sessionStorageMutations.ts
@@ -74,6 +74,7 @@ export function reorderSessions(oldIndex: number, newIndex: number) {
 
 export function copySession(
   sourceMeta: SessionMeta & {
+    name?: Session['name']
     messages?: Session['messages']
     threads?: Session['threads']
     threadName?: Session['threadName']
@@ -82,6 +83,7 @@ export function copySession(
   const source = getSession(sourceMeta.id)!
   const newSession = {
     ...omit(source, 'id', 'messages', 'threads', 'messageForksHash'),
+    ...(sourceMeta.name ? { name: sourceMeta.name } : {}),
     messages: sourceMeta.messages ? sourceMeta.messages.map(copyMessage) : source.messages.map(copyMessage),
     threads: sourceMeta.threads ? copyThreads(sourceMeta.threads) : source.threads,
     messageForksHash: undefined, // 不复制分叉数据


### PR DESCRIPTION
### Description
This PR improves the thread-to-session conversion process by:
1. Making new session names consistent with their original thread names
2. Preventing thread history from being incorrectly inherited

### Changes
- Added `name` parameter support to `copySession` function
- Use thread name as new session name when moving thread to new session
- Initialize new session with empty thread list instead of undefined

### Why
- Better user experience: New sessions now maintain the same name as their source threads
- Fixed bug: New sessions no longer inherit thread history from their source sessions

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

- [x] I have read and agree with the above statement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session naming when moving threads to ensure the session name accurately reflects the moved thread.
  - Ensured that new sessions have an empty threads list instead of being undefined.

- **New Features**
  - Added support for customizing the session name when copying sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->