### PR TITLE
Fix width in small screen

### DIFF
--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -114,7 +114,7 @@ export default function Header(props: Props) {
           </IconButton>
         </Box>
       )}
-      <div className={cn('w-full mx-auto flex flex-row', 'pt-2 pb-2')}>
+      <div className={cn('w-full flex flex-row flex-grow pt-2 pb-2')}>
         <Typography
           variant="h6"
           color="inherit"
@@ -125,9 +125,9 @@ export default function Header(props: Props) {
             overflow: 'hidden',
             textOverflow: 'ellipsis',
           }}
-          className="flex items-center"
+          className="flex items-center w-0"
         >
-          <div className={cn('controls flex flex-row cursor-pointer')}>
+          <div className={cn('controls flex flex-row cursor-pointer shrink w-full')}>
             {
               <Typography
                 variant="h6"

--- a/src/renderer/components/Toolbar.tsx
+++ b/src/renderer/components/Toolbar.tsx
@@ -82,10 +82,8 @@ export default function Toolbar() {
       {showUpdateNotification && <UpdateAvailableButton sx={{ mr: 2 }} />}
       {isSmallScreen ? (
         <IconButton
-          edge="start"
           color="inherit"
           aria-label="menu"
-          sx={{ mr: 2 }}
           onClick={() => setOpenSearchDialog(true)}
         >
           <SearchIcon />
@@ -96,7 +94,7 @@ export default function Toolbar() {
           variant="outlined"
           color="inherit"
           startIcon={<SearchIcon />}
-          sx={{ mr: 3 }}
+          sx={{ ml:1, mr: 1 }}
           onClick={() => setOpenSearchDialog(true)}
           size="small"
           className="transform-none opacity-30"
@@ -111,25 +109,21 @@ export default function Toolbar() {
       )}
       {isLargeScreen && (
         <IconButton
-          edge="start"
           color="inherit"
           aria-label="width-full-button"
-          sx={{ mr: 2 }}
           onClick={() => setWidthFull(!widthFull)}
         >
           {widthFull ? <WidthWideIcon /> : <WidthNormalIcon />}
         </IconButton>
       )}
       <IconButton
-        edge="start"
         color="inherit"
         aria-label="thread-history-drawer-button"
-        sx={{ mr: 2 }}
         onClick={() => setThreadHistoryDrawerOpen(true)}
       >
         <HistoryIcon />
       </IconButton>
-      <IconButton edge="start" color="inherit" aria-label="more-menu-button" sx={{}} onClick={handleMoreMenuOpen}>
+      <IconButton color="inherit" aria-label="more-menu-button" onClick={handleMoreMenuOpen}>
         <MoreHorizIcon />
       </IconButton>
       <StyledMenu anchorEl={anchorEl} open={open} onClose={handleMoreMenuClose}>

--- a/src/renderer/modals/ProviderSelector.tsx
+++ b/src/renderer/modals/ProviderSelector.tsx
@@ -26,7 +26,8 @@ const ProviderSelector = NiceModal.create(() => {
         modal.resolve()
         modal.hide()
       }}
-      maxWidth="sm"
+      maxWidth="xs"
+      fullWidth
     >
       <DialogContent>
         <Box sx={{ textAlign: 'center', mb: 2 }}>
@@ -34,7 +35,7 @@ const ProviderSelector = NiceModal.create(() => {
             {t('Select and configure an AI model provider')}
           </p>
         </Box>
-        <List sx={{ width: '100%', minWidth: 360 }}>
+        <List sx={{ width: '100%' }}>
           {AIModelProviderMenuOptionList.map((provider) => (
             <ListItem key={provider.value} disablePadding>
               <ListItemButton

--- a/src/renderer/modals/Welcome.tsx
+++ b/src/renderer/modals/Welcome.tsx
@@ -20,6 +20,7 @@ const Welcome = NiceModal.create(() => {
         modal.hide()
       }}
       maxWidth="xs"
+      fullWidth
     >
       <DialogContent>
         <Box sx={{ textAlign: 'center', padding: '12px 24px' }}>

--- a/src/renderer/routes/__root.tsx
+++ b/src/renderer/routes/__root.tsx
@@ -86,8 +86,8 @@ function Root() {
             flexGrow: 1,
             ...(showSidebar
               ? language === 'ar'
-                ? { marginRight: { sm: `${sidebarWidth}px` } }
-                : { marginLeft: { sm: `${sidebarWidth}px` } }
+                ? { paddingRight: { sm: `${sidebarWidth}px` } }
+                : { paddingLeft: { sm: `${sidebarWidth}px` } }
               : {}),
           }}
         >


### PR DESCRIPTION
### Description

修复小屏中布局溢出问题

### Additional Notes

之前标题栏中所有按钮都使用了 `edge="start"` 属性，导致按钮会覆盖到左侧元素中，并使用 `mr:2` 属性额外空出边距。

实际上这是对 `edge="start"` 属性的误用。在MUI中有一个应用栏组件，该组件两侧默认带有为标题留出的边距。但是 `IconButton` 本身就有一定的边距，所以需要使用`edge="start|end"`减去`12px`的边距，使其符合 Material 规范。

### Screenshots

| 元素 | 之前 | 之后 |
|-|-|-|
| 模型选择列表 | ![屏幕截图_21-5-2025_212338_web chatboxai app](https://github.com/user-attachments/assets/781ff7c7-f7da-4f93-83d5-fce73ec5406f) | ![屏幕截图_21-5-2025_212329_localhost](https://github.com/user-attachments/assets/fc2d57d0-25ab-4ab2-aa05-46771504e8f1) |
| 图片生成模型标题栏 | ![屏幕截图_21-5-2025_213358_web chatboxai app](https://github.com/user-attachments/assets/0cddeb28-eb3c-433b-a8b1-1a9120d5fd54) | ![屏幕截图_21-5-2025_213350_localhost](https://github.com/user-attachments/assets/3e55beb3-b7e5-4a02-9cfe-73e20c8bae7e) |
| 设置页面 | ![屏幕截图_21-5-2025_215057_web chatboxai app](https://github.com/user-attachments/assets/aed66459-021b-4397-ad68-5876132eab94) | ![屏幕截图_21-5-2025_214911_localhost](https://github.com/user-attachments/assets/c0ded37d-945a-4f46-850d-814024c99f84) |


### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[X] I have read and agree with the above statement.
