### PR TITLE
fix: use logical keys for shortcuts (fixes non-QWERTY layouts)

### DIFF
--- a/src/renderer/hooks/useShortcut.tsx
+++ b/src/renderer/hooks/useShortcut.tsx
@@ -40,11 +40,11 @@ function keyboardShortcut(e: KeyboardEvent, navigate?: NavigationCallback) {
 
   const ctrlKey = getOS() === 'Mac' ? e.metaKey : e.ctrlKey
 
-  if (e.code === 'KeyI' && ctrlKey) {
+  if (e.key === 'i' && ctrlKey) {
     dom.focusMessageInput()
     return
   }
-  if (e.code === 'KeyE' && ctrlKey) {
+  if (e.key === 'e' && ctrlKey) {
     dom.focusMessageInput()
     const store = getDefaultStore()
     store.set(atoms.inputBoxWebBrowsingModeAtom, (v) => !v)
@@ -52,22 +52,22 @@ function keyboardShortcut(e: KeyboardEvent, navigate?: NavigationCallback) {
   }
 
   // 创建新会话 CmdOrCtrl + N
-  if (e.code === 'KeyN' && ctrlKey && !shift) {
+  if (e.key === 'n' && ctrlKey && !shift) {
     sessionActions.createEmpty('chat')
     return
   }
   // 创建新图片会话 CmdOrCtrl + Shift + N
-  if (e.code === 'KeyN' && ctrlKey && shift) {
+  if (e.key === 'n' && ctrlKey && shift) {
     sessionActions.createEmpty('picture')
     return
   }
   // 归档当前会话的上下文。
-  // if (e.code === 'KeyR' && altOrOption) {
+  // if (e.key === 'r' && altOrOption) {
   //     e.preventDefault()
   //     sessionActions.startNewThread()
   //     return
   // }
-  if (e.code === 'KeyR' && ctrlKey) {
+  if (e.key === 'r' && ctrlKey) {
     e.preventDefault()
     sessionActions.startNewThread()
     return
@@ -85,7 +85,7 @@ function keyboardShortcut(e: KeyboardEvent, navigate?: NavigationCallback) {
     }
   }
 
-  if (e.code === 'KeyK' && ctrlKey) {
+  if (e.key === 'k' && ctrlKey) {
     const store = getDefaultStore()
     const openSearchDialog = store.get(atoms.openSearchDialogAtom)
     if (openSearchDialog) {
@@ -94,7 +94,7 @@ function keyboardShortcut(e: KeyboardEvent, navigate?: NavigationCallback) {
       store.set(atoms.openSearchDialogAtom, true)
     }
   }
-  if (e.code === 'Comma' && e.metaKey && navigate) {
+  if (e.key === ',' && e.metaKey && navigate) {
     e.preventDefault()
     navigate('/settings')
     return


### PR DESCRIPTION
### Description
Fixes https://github.com/chatboxai/chatbox/issues/2374

Fixed keyboard shortcuts for Dvorak and other layouts.

Keyboard shortcuts were using e.code (physical key position) instead of e.key (logical key meaning), breaking functionality for Dvorak and other keyboard layouts.

For example, Dvorak users pressing Cmd+C would trigger the Cmd+I handler because 'C' is physically located where 'I' is on QWERTY.

Fix: Replace e.code === 'KeyX' with e.key === 'x' for all keyboard shortcuts for letter keys and comma.

### Additional Notes

I tested this by building on macOS. After the fix, both QWERTY and Dvorak have working shortcuts.

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

- [x] I have read and agree with the above statement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of keyboard shortcuts by updating key detection logic for letter and comma keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->