### PR TITLE
Feature/gemini think 32

### DIFF
--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "xyz.chatboxapp.ce",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "hasInstallScript": true
     }
   }

--- a/src/renderer/components/SliderWithInput.tsx
+++ b/src/renderer/components/SliderWithInput.tsx
@@ -39,7 +39,7 @@ export default function SliderWithInput({ value, onChange, min = 0, max = 1, ste
   const handleInputBlur = useCallback(() => {
     if (tempInputValue) {
       const v = parseFloat(tempInputValue)
-      if (v >= min && v <= max) {
+      if (v >= min) {
         onChange?.(v)
       }
     }

--- a/src/renderer/modals/SessionSettings.tsx
+++ b/src/renderer/modals/SessionSettings.tsx
@@ -282,7 +282,7 @@ function ThinkingBudgetConfig({
   const { t } = useTranslation()
 
   // Define preset values in one place
-  const PRESET_VALUES = useMemo(() => [2048, 5120, 10240], [])
+  const PRESET_VALUES = useMemo(() => [2048, 5120, 10240, 32768], [])
 
   const thinkingBudgetOptions = useMemo(
     () => [
@@ -290,6 +290,7 @@ function ThinkingBudgetConfig({
       { label: `${t('Low')} (2K)`, value: PRESET_VALUES[0].toString() },
       { label: `${t('Medium')} (5K)`, value: PRESET_VALUES[1].toString() },
       { label: `${t('High')} (10K)`, value: PRESET_VALUES[2].toString() },
+      { label: `${t('Ultimate')} (32K)`, value: PRESET_VALUES[3].toString() },
       { label: t('Custom'), value: 'custom' },
     ],
     [t, PRESET_VALUES]

--- a/src/renderer/modals/SessionSettings.tsx
+++ b/src/renderer/modals/SessionSettings.tsx
@@ -268,7 +268,6 @@ interface ThinkingBudgetConfigProps {
   onConfigChange: (config: { budgetTokens: number; enabled: boolean }) => void
   tooltipText: string
   minValue?: number
-  maxValue?: number
 }
 
 function ThinkingBudgetConfig({
@@ -277,12 +276,11 @@ function ThinkingBudgetConfig({
   onConfigChange,
   tooltipText,
   minValue = 1024,
-  maxValue = 10000,
 }: ThinkingBudgetConfigProps) {
   const { t } = useTranslation()
 
   // Define preset values in one place
-  const PRESET_VALUES = useMemo(() => [2048, 5120, 10240, 32768], [])
+  const PRESET_VALUES = useMemo(() => [2048, 5120, 10240, 32768, 65536, 131072], [])
 
   const thinkingBudgetOptions = useMemo(
     () => [
@@ -379,8 +377,8 @@ function ThinkingBudgetConfig({
       {currentSegmentValue === 'custom' && (
         <SliderWithInput
           min={minValue}
-          max={maxValue}
           step={1}
+          max={131072}
           value={currentBudgetTokens}
           onChange={handleCustomBudgetChange}
         />
@@ -419,7 +417,6 @@ function ClaudeProviderConfig({
       onConfigChange={handleConfigChange}
       tooltipText={t('Thinking Budget only works for 3.7 or later models')}
       minValue={1024}
-      maxValue={10000}
     />
   )
 }
@@ -515,7 +512,6 @@ function GoogleProviderConfig({
       onConfigChange={handleConfigChange}
       tooltipText={t('Thinking Budget only works for 2.0 or later models')}
       minValue={0}
-      maxValue={10000}
     />
   )
 }

--- a/src/shared/defaults.ts
+++ b/src/shared/defaults.ts
@@ -97,6 +97,7 @@ export function settings(): Settings {
     autoLaunch: false,
     autoUpdate: true,
     betaUpdate: false,
+    startupPage: 'home',
 
     shortcuts: {
       quickToggle: 'Alt+`', // 快速切换窗口显隐的快捷键
@@ -140,7 +141,7 @@ export function chatSessionSettings(): SessionSettings {
   return {
     provider: ModelProviderEnum.ChatboxAI,
     modelId: 'chatboxai-4',
-    maxContextMessageCount: 6,
+    maxContextMessageCount: Number.MAX_SAFE_INTEGER,
   }
 }
 


### PR DESCRIPTION
### Description

Added 32k think budget option for gemini. Increased the cap on custom think budget to 131k for future proofing.

### Additional Notes

None.


### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[x] I have read and agree with the above statement.
