### PR TITLE
Allow '=' in environment variables values

### DIFF
--- a/src/renderer/components/settings/mcp/utils.ts
+++ b/src/renderer/components/settings/mcp/utils.ts
@@ -8,7 +8,10 @@ const envUtils = {
     const lines = env.split('\n')
     const result: Record<string, string> = {}
     for (const line of lines) {
-      const [key, value] = line.split('=')
+      const eqIndex = line.indexOf('=')
+      if (eqIndex === -1) continue
+      const key = line.slice(0, eqIndex)
+      const value = line.slice(eqIndex + 1)
       if (key && value && key.trim() && value.trim()) {
         result[key.trim()] = value.trim()
       }


### PR DESCRIPTION
### Description

The problem being solved:
Today when we configure local MPCs with environment variables, we sometimes run into an issue. When value of the variable includes '=', the part of the value starting with '=' is removed.

This prevents us from using Atlassian MCP, because every API Key of Atlassian includes '=' character.

### Additional Notes

### Screenshots

![Screenshot 2025-06-25 at 15 52 50](https://github.com/user-attachments/assets/dd2b9235-2ae9-49b4-9b2b-4e88c80c88ef)
![Screenshot 2025-06-25 at 15 52 55](https://github.com/user-attachments/assets/e523f5a4-1733-42e8-a735-92eddba4ecfc)

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[x] I have read and agree with the above statement.
