### PR TITLE
Add Perplexity citations

### DIFF
--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -24,6 +24,7 @@ import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import PlayCircleIcon from '@mui/icons-material/PlayCircle'
 import NiceModal from '@ebay/nice-modal-react'
+import { MessageCitation } from '../../shared/types'
 
 export default function Markdown(props: {
   children: string
@@ -33,6 +34,7 @@ export default function Markdown(props: {
   className?: string
   generating?: boolean
   preferCollapsedCodeBlock?: boolean
+  citations?: MessageCitation[]
 }) {
   const {
     children,
@@ -42,7 +44,24 @@ export default function Markdown(props: {
     preferCollapsedCodeBlock,
     className,
     generating,
+    citations,
   } = props
+
+  // Append sources to the text content
+  const contentWithSources = useMemo(() => {
+    let content = children
+
+    if (citations && citations.length > 0) {
+      // Add sources section to the end of the content
+      content += '\n\nSources:\n'
+      citations.forEach((citation) => {
+        content += `[${citation.number}] ${citation.url}\n`
+      })
+    }
+
+    return content
+  }, [children, citations])
+
   return useMemo(
     () => (
       <ReactMarkdown
@@ -73,10 +92,18 @@ export default function Markdown(props: {
           ),
         }}
       >
-        {enableLaTeXRendering ? latex.processLaTeX(children) : children}
+        {enableLaTeXRendering ? latex.processLaTeX(contentWithSources) : contentWithSources}
       </ReactMarkdown>
     ),
-    [children, enableLaTeXRendering, enableMermaidRendering]
+    [
+      contentWithSources,
+      enableLaTeXRendering,
+      enableMermaidRendering,
+      hiddenCodeCopyButton,
+      generating,
+      preferCollapsedCodeBlock,
+      className,
+    ]
   )
 }
 

--- a/src/renderer/components/Message.tsx
+++ b/src/renderer/components/Message.tsx
@@ -16,6 +16,7 @@ import type React from 'react'
 import { type FC, type MouseEventHandler, memo, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Markdown from '@/components/Markdown'
+import Citations from '@/components/Citations'
 import type { Message, SessionType } from '../../shared/types'
 import {
   autoCollapseCodeBlockAtom,
@@ -560,6 +561,7 @@ const Message: FC<Props> = (props) => {
                                 autoCollapseCodeBlock &&
                                 (preferCollapsedCodeBlock || msg.role !== 'assistant' || previewArtifact)
                               }
+                              citations={msg.citations}
                             >
                               {item.text || ''}
                             </Markdown>

--- a/src/renderer/components/Message.tsx
+++ b/src/renderer/components/Message.tsx
@@ -560,6 +560,7 @@ const Message: FC<Props> = (props) => {
                                 autoCollapseCodeBlock &&
                                 (preferCollapsedCodeBlock || msg.role !== 'assistant' || previewArtifact)
                               }
+                              citations={msg.citations}
                             >
                               {item.text || ''}
                             </Markdown>

--- a/src/renderer/packages/models/types.ts
+++ b/src/renderer/packages/models/types.ts
@@ -1,5 +1,5 @@
 import { ToolSet } from 'ai'
-import { Message, MessageContentParts, ProviderOptions, StreamTextResult } from 'src/shared/types'
+import { Message, MessageContentParts, MessageCitation, ProviderOptions, StreamTextResult } from 'src/shared/types'
 
 export interface ModelInterface {
   name: string
@@ -24,6 +24,7 @@ export interface ResultChange {
   contentParts?: MessageContentParts
   tokenCount?: number // 当前消息的 token 数量
   tokensUsed?: number // 生成当前消息的 token 使用量
+  citations?: MessageCitation[] // Perplexity AI citations
 }
 
 export type onResultChangeWithCancel = (data: ResultChange & { cancel?: () => void }) => void

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,6 +29,13 @@ export interface MessageLink {
   chatboxAILinkUUID?: string
 }
 
+export interface MessageCitation {
+  id: string
+  url: string
+  title: string
+  number: number // Citation number like [1], [2], etc.
+}
+
 export interface MessagePicture {
   url?: string
   storageKey?: string
@@ -60,6 +67,7 @@ export type StreamTextResult = {
   contentParts: MessageContentParts
   reasoningContent?: string
   usage?: LanguageModelUsage
+  citations?: MessageCitation[]
 }
 
 // Chatbox 应用的消息类型
@@ -82,6 +90,7 @@ export interface Message {
 
   files?: MessageFile[] // chatboxai 专用
   links?: MessageLink[] // chatboxai 专用
+  citations?: MessageCitation[] // Perplexity AI citations
 
   // webBrowsing?: MessageWebBrowsing // chatboxai 专用, （已废弃）
   // toolCalls?: MessageToolCalls // 已废弃，使用contentParts代替


### PR DESCRIPTION
### Description

Added citation support for responses from Perplexity API to address #2404.

### Additional Notes
Previously, the API's citations were not handled by the application.  Users would see citations like [1] [2] in-text, but their corresponding links were not provided.
Now, they are captured in the response and applied at the end of the message with accessible links, as shown in the screenshot.

### Screenshots

<img width="951" height="592" alt="68Bwt14JvQ" src="https://github.com/user-attachments/assets/8125e8e5-ba7e-4d15-93e6-3a996920680e" />


### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

[X] I have read and agree with the above statement.
