### PR TITLE
feat: add a setting option for auto-collapse thinking blocks

### DIFF
--- a/src/renderer/i18n/locales/ar/translation.json
+++ b/src/renderer/i18n/locales/ar/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "تلقائي (استخدام Chatbox AI)",
   "Auto (Use Last Used)": "تلقائي (استخدام آخر نموذج مستخدم)",
   "Auto-collapse code blocks": "تلقائيًا إخفاء الكتل البرمجية",
+  "Auto-collapse thinking blocks": "تلقائيًا إخفاء كتل التفكير",
   "Auto-Generate Chat Titles": "تلقائيًا إنشاء عناوين المحادثات",
   "Auto-preview artifacts": "معاينة تلقائية للتحف",
   "Automatic updates": "تحديثات تلقائية",

--- a/src/renderer/i18n/locales/de/translation.json
+++ b/src/renderer/i18n/locales/de/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "Automatisch (Chatbox AI verwenden)",
   "Auto (Use Last Used)": "Automatisch (Letztes verwendetes Modell verwenden)",
   "Auto-collapse code blocks": "Automatisch Codeblöcke schließen",
+  "Auto-collapse thinking blocks": "Automatisch Denkblöcke schließen",
   "Auto-Generate Chat Titles": "Automatisch Chat-Titel generieren",
   "Auto-preview artifacts": "Artefakte automatisch anzeigen",
   "Automatic updates": "Automatische Updates",

--- a/src/renderer/i18n/locales/en/translation.json
+++ b/src/renderer/i18n/locales/en/translation.json
@@ -44,6 +44,7 @@
   "Auto (Use Chatbox AI)": "Auto (Use Chatbox AI)",
   "Auto (Use Last Used)": "Auto (Use Last Used)",
   "Auto-collapse code blocks": "Auto-collapse code blocks",
+  "Auto-collapse thinking blocks": "Auto-collapse thinking blocks",
   "Auto-Generate Chat Titles": "Auto-Generate Chat Titles",
   "Auto-preview artifacts": "Auto-preview artifacts",
   "Automatic updates": "Automatic updates",

--- a/src/renderer/i18n/locales/es/translation.json
+++ b/src/renderer/i18n/locales/es/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "Automático (Usar Chatbox AI)",
   "Auto (Use Last Used)": "Automático (Usar el último utilizado)",
   "Auto-collapse code blocks": "Auto-ocultar bloques de código",
+  "Auto-collapse thinking blocks": "Auto-ocultar bloques de pensamiento",
   "Auto-Generate Chat Titles": "Auto-Generar títulos de chat",
   "Auto-preview artifacts": "Vista previa automática de artefactos",
   "Automatic updates": "Actualizaciones automáticas",

--- a/src/renderer/i18n/locales/fr/translation.json
+++ b/src/renderer/i18n/locales/fr/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "Auto (Utiliser Chatbox AI)",
   "Auto (Use Last Used)": "Auto (Utiliser le dernier utilisé)",
   "Auto-collapse code blocks": "Réduire automatiquement les blocs de code",
+  "Auto-collapse thinking blocks": "Réduire automatiquement les blocs de réflexion",
   "Auto-Generate Chat Titles": "Auto-Générer les titres des conversations",
   "Auto-preview artifacts": "Aperçu automatique des artefacts",
   "Automatic updates": "Mises à jour automatiques",

--- a/src/renderer/i18n/locales/it-IT/translation.json
+++ b/src/renderer/i18n/locales/it-IT/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "Automatico (Utilizza Chatbox AI)",
   "Auto (Use Last Used)": "Auto (Usa l'ultimo utilizzato)",
   "Auto-collapse code blocks": "Auto-nascondi blocchi di codice",
+  "Auto-collapse thinking blocks": "Auto-nascondi blocchi di pensiero",
   "Auto-Generate Chat Titles": "Auto-Genera titoli di chat",
   "Auto-preview artifacts": "Anteprima automatica degli artefatti",
   "Automatic updates": "Aggiornamenti automatici",

--- a/src/renderer/i18n/locales/ja/translation.json
+++ b/src/renderer/i18n/locales/ja/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "自動 (Chatbox AI を使用)",
   "Auto (Use Last Used)": "自動（最後に使用したものを使用）",
   "Auto-collapse code blocks": "コードブロックを自動的に折りたたむ",
+  "Auto-collapse thinking blocks": "思考ブロックを自動的に折りたたむ",
   "Auto-Generate Chat Titles": "チャットのタイトルを自動生成",
   "Auto-preview artifacts": "アーティファクトを自動プレビュー",
   "Automatic updates": "自動更新",

--- a/src/renderer/i18n/locales/ko/translation.json
+++ b/src/renderer/i18n/locales/ko/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "자동 (Chatbox AI 사용)",
   "Auto (Use Last Used)": "자동 (마지막 사용 모델 사용)",
   "Auto-collapse code blocks": "코드 블록 자동 숨기기",
+  "Auto-collapse thinking blocks": "사고 블록 자동 숨기기",
   "Auto-Generate Chat Titles": "채팅 제목 자동 생성",
   "Auto-preview artifacts": "아티팩트 자동 미리보기",
   "Automatic updates": "자동 업데이트",

--- a/src/renderer/i18n/locales/nb-NO/translation.json
+++ b/src/renderer/i18n/locales/nb-NO/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "Auto (Bruk Chatbox AI)",
   "Auto (Use Last Used)": "Auto (Bruk sist brukt)",
   "Auto-collapse code blocks": "Skjul kodeblokker automatisk",
+  "Auto-collapse thinking blocks": "Skjul tankeblokker automatisk",
   "Auto-Generate Chat Titles": "Generer chattitler automatisk",
   "Auto-preview artifacts": "Automatisk forhåndsvisning av artefakter",
   "Automatic updates": "Automatisk oppdatering",

--- a/src/renderer/i18n/locales/pt-PT/translation.json
+++ b/src/renderer/i18n/locales/pt-PT/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "Automático (Usar Chatbox AI)",
   "Auto (Use Last Used)": "Automático (Usar Último Usado)",
   "Auto-collapse code blocks": "Auto-esconder blocos de código",
+  "Auto-collapse thinking blocks": "Auto-esconder blocos de pensamento",
   "Auto-Generate Chat Titles": "Auto-Gerar títulos de chat",
   "Auto-preview artifacts": "Pré-visualização automática de artefatos",
   "Automatic updates": "Atualizações automáticas",

--- a/src/renderer/i18n/locales/ru/translation.json
+++ b/src/renderer/i18n/locales/ru/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "Авто (Использовать Chatbox AI)",
   "Auto (Use Last Used)": "Авто (использовать последний использованный)",
   "Auto-collapse code blocks": "Автоматически скрывать блоки кода",
+  "Auto-collapse thinking blocks": "Автоматически скрывать блоки размышлений",
   "Auto-Generate Chat Titles": "Автоматически генерировать названия чатов",
   "Auto-preview artifacts": "Автоматический предпросмотр артефактов",
   "Automatic updates": "Автоматические обновления",

--- a/src/renderer/i18n/locales/sv/translation.json
+++ b/src/renderer/i18n/locales/sv/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "Auto (Använd Chatbox AI)",
   "Auto (Use Last Used)": "Auto (Använd senast använd)",
   "Auto-collapse code blocks": "Minimera kodblock automatiskt",
+  "Auto-collapse thinking blocks": "Minimera tankeblock automatiskt",
   "Auto-Generate Chat Titles": "Generera chattrubriker automatiskt",
   "Auto-preview artifacts": "Förhandsgranska artefakter automatiskt",
   "Automatic updates": "Automatisk uppdatering",

--- a/src/renderer/i18n/locales/zh-Hans/translation.json
+++ b/src/renderer/i18n/locales/zh-Hans/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "自动 (使用 Chatbox AI)",
   "Auto (Use Last Used)": "自动（使用上次使用的模型）",
   "Auto-collapse code blocks": "自动收起代码块",
+  "Auto-collapse thinking blocks": "自动收起思考块",
   "Auto-Generate Chat Titles": "自动生成聊天标题",
   "Auto-preview artifacts": "自动预览生成物(Artifacts)",
   "Automatic updates": "自动更新",

--- a/src/renderer/i18n/locales/zh-Hant/translation.json
+++ b/src/renderer/i18n/locales/zh-Hant/translation.json
@@ -62,6 +62,7 @@
   "Auto (Use Chatbox AI)": "自動 (使用 Chatbox AI)",
   "Auto (Use Last Used)": "自動（使用上次使用的模型）",
   "Auto-collapse code blocks": "自動收起代碼塊",
+  "Auto-collapse thinking blocks": "自動收起思考塊",
   "Auto-Generate Chat Titles": "自動生成聊天標題",
   "Auto-preview artifacts": "自動預覽生成內容(Artifacts)",
   "Automatic updates": "自動更新",

--- a/src/renderer/routes/settings/chat.tsx
+++ b/src/renderer/routes/settings/chat.tsx
@@ -307,6 +307,16 @@ function RouteComponent() {
             }
           />
           <Switch
+            label={t('Auto-collapse thinking blocks')}
+            checked={settings.autoCollapseThinkingBlocks}
+            onChange={() =>
+              setSettings({
+                ...settings,
+                autoCollapseThinkingBlocks: !settings.autoCollapseThinkingBlocks,
+              })
+            }
+          />
+          <Switch
             label={t('Auto-Generate Chat Titles')}
             checked={settings.autoGenerateTitle}
             onChange={() =>

--- a/src/renderer/stores/atoms/settingsAtoms.ts
+++ b/src/renderer/stores/atoms/settingsAtoms.ts
@@ -77,6 +77,7 @@ export const autoGenerateTitleAtom = focusAtom(settingsAtom, (optic) => optic.pr
 export const autoCollapseCodeBlockAtom = focusAtom(settingsAtom, (optic) => optic.prop('autoCollapseCodeBlock'))
 export const shortcutsAtom = focusAtom(settingsAtom, (optic) => optic.prop('shortcuts'))
 export const pasteLongTextAsAFileAtom = focusAtom(settingsAtom, (optic) => optic.prop('pasteLongTextAsAFile'))
+export const autoCollapseThinkingBlocksAtom = focusAtom(settingsAtom, (optic) => optic.prop('autoCollapseThinkingBlocks'))
 // export const licenseDetailAtom = focusAtom(settingsAtom, (optic) => optic.prop('licenseDetail'))
 
 // Related UI state, moved here for proximity to settings

--- a/src/shared/defaults.ts
+++ b/src/shared/defaults.ts
@@ -98,6 +98,7 @@ export function settings(): Settings {
     injectDefaultMetadata: true,
     autoPreviewArtifacts: false,
     autoCollapseCodeBlock: true,
+    autoCollapseThinkingBlocks: false,
     pasteLongTextAsAFile: true,
 
     autoGenerateTitle: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -416,6 +416,7 @@ export interface Settings extends SessionSettings {
   injectDefaultMetadata: boolean // 是否注入默认附加元数据（如模型名称、当前日期）
   autoPreviewArtifacts: boolean // 是否自动展开预览 artifacts
   autoCollapseCodeBlock: boolean // 是否自动折叠代码块
+  autoCollapseThinkingBlocks: boolean // 是否自动折叠思考块
   pasteLongTextAsAFile: boolean // 是否将长文本粘贴为文件
 
   autoGenerateTitle: boolean


### PR DESCRIPTION
### Description

- add an option to "auto collapse thinking blocks" and implement this feature. （新增“自动折叠思考块”的设置和特性）
- translate the newly added text. （完成新增文本的翻译）
- test the feature on macos

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[x] I have read and agree with the above statement.
