### PR TITLE
feat: add Bright Data MCP

### DIFF
--- a/src/renderer/components/settings/mcp/registries.ts
+++ b/src/renderer/components/settings/mcp/registries.ts
@@ -45,6 +45,21 @@ export const MCP_ENTRIES_OFFICIAL: MCPRegistryEntry[] = [
     },
   },
   {
+    name: 'bright-data',
+    title: 'The Web MCP',
+    description:
+      'Discover, extract, and interact with the web - one interface powering automated access across the public internet.',
+    icon: 'https://brightdata.com/wp-content/themes/brightdata/assets/images/favicon.png',
+    homepage: 'https://github.com/brightdata/brightdata-mcp',
+    configuration: {
+      command: 'npx',
+      args: ['@brightdata/mcp'],
+      env: {
+        API_TOKEN: "your-token-here"
+      },
+    },
+  },
+  {
     name: 'chroma',
     title: 'Chroma',
     description:


### PR DESCRIPTION
### Description

This PR adds the Bright Data MCP server (The Web MCP) to the official MCP registry entries in Chatbox AI.

**Main changes:**
- Added Bright Data MCP configuration to the `MCP_ENTRIES_OFFICIAL` array
- Configured the server to run via `npx @brightdata/mcp` with API token authentication
- Used Bright Data's official favicon as the icon
- Positioned the entry between Brave Search and Chroma in the official entries list

**Integration details:**
- **Name:** bright-data
- **Title:** The Web MCP
- **Command:** `npx @brightdata/mcp`
- **Environment variable:** `API_TOKEN` (users need to provide their own token)
- **Homepage:** https://github.com/brightdata/brightdata-mcp

This addition enables Chatbox AI users to leverage Bright Data's web scraping and data extraction capabilities through the MCP protocol, providing automated access to public web data.

### Additional Notes

- Users will need to obtain their own API token from Bright Data and replace `"your-token-here"` in the configuration
- The integration follows the same pattern as other official MCP servers in the registry (Brave Search, Exa, etc.)
- The Bright Data MCP provides web discovery, extraction, and interaction capabilities that complement existing search and data tools

### Screenshots

[No screenshots needed for this configuration-only change]

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

- [x] I have read and agree with the above statement.