### PR TITLE
add browser-use mcp server

### DIFF
--- a/src/renderer/components/settings/mcp/registries.ts
+++ b/src/renderer/components/settings/mcp/registries.ts
@@ -607,4 +607,16 @@ export const MCP_ENTRIES_COMMUNITY: MCPRegistryEntry[] = [
       },
     },
   },
+  {
+    name: 'browser-use',
+    title: 'Browser Use',
+    description:
+      'Browser automation with real-time web access and search capabilities. Provides tools for executing browser tasks, managing persistent authentication profiles, and monitoring task progress.',
+    icon: 'https://browser-use.com/favicon.ico',
+    homepage: 'https://github.com/browser-use/browser-use',
+    configuration: {
+      command: 'npx',
+      args: ['mcp-remote', 'https://api.browser-use.com/mcp', '--header', 'X-Browser-Use-API-Key: <YOUR_API_KEY>'],
+    },
+  },
 ]


### PR DESCRIPTION
### Description

This PR adds the **Browser Use** MCP server to the community registry, enabling users to perform browser automation tasks directly through Chatbox.

**Main Changes:**
- Added a new MCP registry entry for "browser-use" in `src/renderer/components/settings/mcp/registries.ts`
- Configured the server to connect via `npx mcp-remote` to the Browser Use API endpoint

**Features provided by Browser Use MCP:**
- Browser automation with real-time web access and search capabilities
- Tools for executing browser tasks programmatically
- Persistent authentication profile management for maintaining logged-in sessions
- Task progress monitoring for long-running automation workflows

**Configuration:**
- **Command:** `npx mcp-remote https://api.browser-use.com/mcp`
- **Authentication:** Requires API key via `X-Browser-Use-API-Key` header
- **Homepage:** https://github.com/browser-use/browser-use

Users can now select "Browser Use" from the MCP server settings in Chatbox, add their API key, and enable AI agents to perform browser-based operations such as web scraping, form filling, automated testing, or general web navigation tasks.

### Additional Notes

- This is a registry-only addition with no code logic changes
- Users will need to obtain an API key from browser-use.com to use this MCP server
- The server runs remotely via the Browser Use API, so no local installation is required beyond the `mcp-remote` package

### Screenshots

N/A - This is a backend registry addition. The Browser Use option will appear in the MCP server selection dropdown in Settings.

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[X] I have read and agree with the above statement.