### PR TITLE
fix: export permission error on Android/Huawei devices

### DIFF
--- a/src/renderer/platform/index.ts
+++ b/src/renderer/platform/index.ts
@@ -1,10 +1,14 @@
 import DesktopPlatform from './desktop_platform'
 import { Platform } from './interfaces'
+import MobilePlatform from './mobile_platform'
 import WebPlatform from './web_platform'
+import { CHATBOX_BUILD_TARGET } from '../variables'
 
 function initPlatform(): Platform {
   if (window.electronAPI) {
     return new DesktopPlatform(window.electronAPI)
+  } else if (CHATBOX_BUILD_TARGET === 'mobile_app') {
+    return new MobilePlatform()
   } else {
     return new WebPlatform()
   }

--- a/src/renderer/platform/mobile_exporter.ts
+++ b/src/renderer/platform/mobile_exporter.ts
@@ -1,0 +1,135 @@
+import { Directory, Filesystem } from '@capacitor/filesystem'
+import { Share } from '@capacitor/share'
+import * as base64 from '@/packages/base64'
+import type { Exporter } from './interfaces'
+
+export default class MobileExporter implements Exporter {
+  constructor() {}
+
+  private async shareFile(filename: string, blob: Blob, mimeType: string) {
+    try {
+      // Convert blob to base64
+      const reader = new FileReader()
+      const base64Data = await new Promise<string>((resolve, reject) => {
+        reader.onloadend = () => {
+          const result = reader.result as string
+          // Remove data URL prefix (e.g., "data:image/png;base64,")
+          const base64String = result.split(',')[1] || result
+          resolve(base64String)
+        }
+        reader.onerror = reject
+        reader.readAsDataURL(blob)
+      })
+
+      // Write file to cache directory
+      const result = await Filesystem.writeFile({
+        path: filename,
+        data: base64Data,
+        directory: Directory.Cache,
+      })
+
+      // Share the file using native share sheet
+      await Share.share({
+        title: filename,
+        text: `Export: ${filename}`,
+        url: result.uri,
+        dialogTitle: 'Export File',
+      })
+
+      // Clean up cache file after a delay to allow share to complete
+      setTimeout(async () => {
+        try {
+          await Filesystem.deleteFile({
+            path: filename,
+            directory: Directory.Cache,
+          })
+        } catch (e) {
+          console.warn('Failed to clean up cache file:', e)
+        }
+      }, 5000)
+    } catch (error) {
+      console.error('Failed to share file:', error)
+      throw new Error(`Failed to export file: ${error}`)
+    }
+  }
+
+  async exportBlob(filename: string, blob: Blob, encoding?: 'utf8' | 'ascii' | 'utf16') {
+    await this.shareFile(filename, blob, blob.type || 'application/octet-stream')
+  }
+
+  async exportTextFile(filename: string, content: string) {
+    const blob = new Blob([content], { type: 'text/plain' })
+    await this.shareFile(filename, blob, 'text/plain')
+  }
+
+  async exportImageFile(basename: string, base64Data: string) {
+    // Parse base64 data
+    let { type, data } = base64.parseImage(base64Data)
+    if (type === '') {
+      type = 'image/png'
+      data = base64Data
+    }
+    const ext = (type.split('/')[1] || 'png').split('+')[0] // Handle svg+xml case
+    const filename = basename + '.' + ext
+
+    try {
+      // Write file to cache directory
+      const result = await Filesystem.writeFile({
+        path: filename,
+        data: data,
+        directory: Directory.Cache,
+      })
+
+      // Share the file using native share sheet
+      await Share.share({
+        title: filename,
+        text: `Export: ${filename}`,
+        url: result.uri,
+        dialogTitle: 'Export Image',
+      })
+
+      // Clean up cache file after a delay to allow share to complete
+      setTimeout(async () => {
+        try {
+          await Filesystem.deleteFile({
+            path: filename,
+            directory: Directory.Cache,
+          })
+        } catch (e) {
+          console.warn('Failed to clean up cache file:', e)
+        }
+      }, 5000)
+    } catch (error) {
+      console.error('Failed to export image:', error)
+      throw new Error(`Failed to export image: ${error}`)
+    }
+  }
+
+  async exportByUrl(filename: string, url: string) {
+    try {
+      // Fetch the file from URL
+      const response = await fetch(url)
+      const blob = await response.blob()
+      await this.shareFile(filename, blob, blob.type || 'application/octet-stream')
+    } catch (error) {
+      console.error('Failed to export from URL:', error)
+      throw new Error(`Failed to export from URL: ${error}`)
+    }
+  }
+
+  async exportStreamingJson(filename: string, dataCallback: () => AsyncGenerator<string, void, unknown>) {
+    try {
+      let content = ''
+      const generator = dataCallback()
+
+      for await (const chunk of generator) {
+        content += chunk
+      }
+
+      await this.exportTextFile(filename, content)
+    } catch (error) {
+      console.error('Failed to export streaming JSON:', error)
+      throw error
+    }
+  }
+}

--- a/src/renderer/platform/mobile_platform.ts
+++ b/src/renderer/platform/mobile_platform.ts
@@ -1,0 +1,217 @@
+import { App } from '@capacitor/app'
+import { Browser } from '@capacitor/browser'
+import { Device } from '@capacitor/device'
+import localforage from 'localforage'
+import * as defaults from 'src/shared/defaults'
+import type { Config, Settings, ShortcutSetting } from 'src/shared/types'
+import { v4 as uuidv4 } from 'uuid'
+import { parseLocale } from '@/i18n/parser'
+import type { Platform, PlatformType } from './interfaces'
+import type { KnowledgeBaseController } from './knowledge-base/interface'
+import MobileExporter from './mobile_exporter'
+import { MobileSQLiteStorage } from './storages'
+import { parseTextFileLocally } from './web_platform_utils'
+
+export default class MobilePlatform extends MobileSQLiteStorage implements Platform {
+  public type: PlatformType = 'mobile'
+
+  public exporter = new MobileExporter()
+
+  public async getVersion(): Promise<string> {
+    const info = await App.getInfo()
+    return info.version
+  }
+
+  public async getPlatform(): Promise<string> {
+    const info = await Device.getInfo()
+    return info.platform
+  }
+
+  public async getArch(): Promise<string> {
+    const info = await Device.getInfo()
+    return info.operatingSystem
+  }
+
+  public async shouldUseDarkColors(): Promise<boolean> {
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+  }
+
+  public onSystemThemeChange(callback: () => void): () => void {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', callback)
+    return () => {
+      window.matchMedia('(prefers-color-scheme: dark)').removeEventListener('change', callback)
+    }
+  }
+
+  public onWindowShow(callback: () => void): () => void {
+    const listener = App.addListener('appStateChange', (state) => {
+      if (state.isActive) {
+        callback()
+      }
+    })
+    return () => {
+      listener.remove()
+    }
+  }
+
+  public onUpdateDownloaded(callback: () => void): () => void {
+    return () => null
+  }
+
+  public async openLink(url: string): Promise<void> {
+    await Browser.open({ url })
+  }
+
+  public async getDeviceName(): Promise<string> {
+    const info = await Device.getInfo()
+    return `${info.manufacturer || ''} ${info.model || ''}`.trim() || 'Unknown Device'
+  }
+
+  public async getInstanceName(): Promise<string> {
+    const info = await Device.getInfo()
+    return `${info.operatingSystem} ${info.osVersion} / ${info.model || 'Mobile'}`
+  }
+
+  public async getLocale() {
+    const info = await Device.getLanguageCode()
+    return parseLocale(info.value)
+  }
+
+  public async ensureShortcutConfig(config: ShortcutSetting): Promise<void> {
+    return
+  }
+
+  public async ensureProxyConfig(config: { proxy?: string }): Promise<void> {
+    return
+  }
+
+  public async relaunch(): Promise<void> {
+    location.reload()
+  }
+
+  public async getConfig(): Promise<Config> {
+    let value: Config = await this.getStoreValue('configs')
+    if (value === undefined || value === null) {
+      value = defaults.newConfigs()
+      await this.setStoreValue('configs', value)
+    }
+    return value
+  }
+
+  public async getSettings(): Promise<Settings> {
+    let value: Settings = await this.getStoreValue('settings')
+    if (value === undefined || value === null) {
+      value = defaults.settings()
+      await this.setStoreValue('settings', value)
+    }
+    return value
+  }
+
+  public async getStoreBlob(key: string): Promise<string | null> {
+    return localforage.getItem<string>(key)
+  }
+
+  public async setStoreBlob(key: string, value: string): Promise<void> {
+    await localforage.setItem(key, value)
+  }
+
+  public async delStoreBlob(key: string) {
+    return localforage.removeItem(key)
+  }
+
+  public async listStoreBlobKeys(): Promise<string[]> {
+    return localforage.keys()
+  }
+
+  public async initTracking() {
+    const GAID = 'G-B365F44W6E'
+    try {
+      const conf = await this.getConfig()
+      const info = await Device.getInfo()
+      window.gtag('config', GAID, {
+        app_name: 'chatbox',
+        user_id: conf.uuid,
+        client_id: conf.uuid,
+        app_version: await this.getVersion(),
+        chatbox_platform_type: 'mobile',
+        chatbox_platform: info.platform,
+        app_platform: info.platform,
+      })
+    } catch (e) {
+      window.gtag('config', GAID, {
+        app_name: 'chatbox',
+      })
+      throw e
+    }
+  }
+
+  public trackingEvent(name: string, params: { [key: string]: string }) {
+    window.gtag('event', name, params)
+  }
+
+  public async shouldShowAboutDialogWhenStartUp(): Promise<boolean> {
+    return false
+  }
+
+  public async appLog(level: string, message: string): Promise<void> {
+    console.log(`APP_LOG: [${level}] ${message}`)
+  }
+
+  public async ensureAutoLaunch(enable: boolean) {
+    return
+  }
+
+  async parseFileLocally(file: File): Promise<{ key?: string; isSupported: boolean }> {
+    const result = await parseTextFileLocally(file)
+    if (!result.isSupported) {
+      return { isSupported: false }
+    }
+    const key = `parseFile-` + uuidv4()
+    await this.setStoreBlob(key, result.text)
+    return { key, isSupported: true }
+  }
+
+  public async parseUrl(url: string): Promise<{ key: string; title: string }> {
+    throw new Error('Not implemented')
+  }
+
+  public async isFullscreen() {
+    return true
+  }
+
+  public async setFullscreen(enabled: boolean): Promise<void> {
+    return
+  }
+
+  installUpdate(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+
+  public getKnowledgeBaseController(): KnowledgeBaseController {
+    throw new Error('Method not implemented.')
+  }
+
+  public minimize() {
+    return Promise.resolve()
+  }
+
+  public maximize() {
+    return Promise.resolve()
+  }
+
+  public unmaximize() {
+    return Promise.resolve()
+  }
+
+  public closeWindow() {
+    return Promise.resolve()
+  }
+
+  public isMaximized() {
+    return Promise.resolve(true)
+  }
+
+  public onMaximizedChange() {
+    return () => null
+  }
+}


### PR DESCRIPTION
Fixed the "Parent folder doesn't exist" error when exporting files on Huawei devices (HarmonyOS/Android) by implementing proper mobile platform support using Capacitor APIs.

Changes:
- Created MobileExporter class that uses Capacitor Share API instead of browser download mechanism
- Created MobilePlatform class for mobile-specific platform handling
- Updated platform initialization to detect mobile builds and use MobilePlatform

The fix replaces the browser-style download (anchor tag click) which doesn't work properly in Capacitor WebView with native share sheet that works correctly on all Android devices including Huawei.

Fixes: https://iftechio.slack.com/archives/C0A5UNJQGPQ/p1768546806172309

### Description

[Please provide a detailed description of your contribution, including the main changes and their purpose]

### Additional Notes

[If you have any additional comments or notes, please add them here]

### Screenshots

[Optional: Include screenshots that help explain your PR]

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[ ] I have read and agree with the above statement.
