### PR TITLE
feat: add Bedrock API Key auth and dynamic model fetching

### DIFF
--- a/src/renderer/routes/settings/provider/$providerId.tsx
+++ b/src/renderer/routes/settings/provider/$providerId.tsx
@@ -853,35 +853,73 @@ function ProviderSettings({ providerId }: { providerId: string }) {
           <>
             <Stack gap="xxs">
               <Text span fw="600">
-                {t('AWS Access Key ID')}
+                {t('Authentication')}
               </Text>
-              <PasswordInput
-                flex={1}
-                value={providerSettings?.accessKey || ''}
-                placeholder="AKIAIOSFODNN7EXAMPLE"
-                onChange={(e) =>
+              <SegmentedControl
+                value={providerSettings?.activeAuthMode === 'iam' ? 'iam' : 'apikey'}
+                onChange={(value) =>
                   setProviderSettings({
-                    accessKey: e.currentTarget.value,
+                    activeAuthMode: value as 'apikey' | 'iam',
                   })
                 }
+                data={[
+                  { label: t('Bedrock API Key'), value: 'apikey' },
+                  { label: t('IAM Credentials'), value: 'iam' },
+                ]}
               />
             </Stack>
 
-            <Stack gap="xxs">
-              <Text span fw="600">
-                {t('AWS Secret Access Key')}
-              </Text>
-              <PasswordInput
-                flex={1}
-                value={providerSettings?.secretKey || ''}
-                placeholder="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-                onChange={(e) =>
-                  setProviderSettings({
-                    secretKey: e.currentTarget.value,
-                  })
-                }
-              />
-            </Stack>
+            {providerSettings?.activeAuthMode === 'iam' ? (
+              <>
+                <Stack gap="xxs">
+                  <Text span fw="600">
+                    {t('AWS Access Key ID')}
+                  </Text>
+                  <PasswordInput
+                    flex={1}
+                    value={providerSettings?.accessKey || ''}
+                    placeholder="AKIAIOSFODNN7EXAMPLE"
+                    onChange={(e) =>
+                      setProviderSettings({
+                        accessKey: e.currentTarget.value,
+                      })
+                    }
+                  />
+                </Stack>
+
+                <Stack gap="xxs">
+                  <Text span fw="600">
+                    {t('AWS Secret Access Key')}
+                  </Text>
+                  <PasswordInput
+                    flex={1}
+                    value={providerSettings?.secretKey || ''}
+                    placeholder="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+                    onChange={(e) =>
+                      setProviderSettings({
+                        secretKey: e.currentTarget.value,
+                      })
+                    }
+                  />
+                </Stack>
+              </>
+            ) : (
+              <Stack gap="xxs">
+                <Text span fw="600">
+                  {t('API Key')}
+                </Text>
+                <PasswordInput
+                  flex={1}
+                  value={providerSettings?.apiKey || ''}
+                  placeholder="bedrock-api-key"
+                  onChange={(e) =>
+                    setProviderSettings({
+                      apiKey: e.currentTarget.value,
+                    })
+                  }
+                />
+              </Stack>
+            )}
 
             <Stack gap="xxs">
               <Text span fw="600">
@@ -902,23 +940,31 @@ function ProviderSettings({ providerId }: { providerId: string }) {
             <Flex gap="xs" align="center">
               <Tooltip
                 disabled={
-                  !!providerSettings?.accessKey &&
-                  !!providerSettings?.secretKey &&
+                  (providerSettings?.activeAuthMode === 'iam'
+                    ? !!providerSettings?.accessKey && !!providerSettings?.secretKey
+                    : !!providerSettings?.apiKey) &&
                   displayModels.length > 0
                 }
                 label={
-                  !providerSettings?.accessKey || !providerSettings?.secretKey
-                    ? t('AWS Access Key ID and Secret Access Key are required to check connection')
-                    : displayModels.length === 0
-                      ? t('Add at least one model to check connection')
-                      : null
+                  providerSettings?.activeAuthMode === 'iam'
+                    ? !providerSettings?.accessKey || !providerSettings?.secretKey
+                      ? t('AWS Access Key ID and Secret Access Key are required to check connection')
+                      : displayModels.length === 0
+                        ? t('Add at least one model to check connection')
+                        : null
+                    : !providerSettings?.apiKey
+                      ? t('API Key is required to check connection')
+                      : displayModels.length === 0
+                        ? t('Add at least one model to check connection')
+                        : null
                 }
               >
                 <Button
                   size="sm"
                   disabled={
-                    !providerSettings?.accessKey ||
-                    !providerSettings?.secretKey ||
+                    (providerSettings?.activeAuthMode === 'iam'
+                      ? !providerSettings?.accessKey || !providerSettings?.secretKey
+                      : !providerSettings?.apiKey) ||
                     displayModels.length === 0
                   }
                   loading={modelTestResult?.testing || false}

--- a/src/shared/providers/definitions/bedrock.ts
+++ b/src/shared/providers/definitions/bedrock.ts
@@ -50,6 +50,7 @@ export const bedrockProvider = defineProvider({
   createModel: (config) => {
     return new Bedrock(
       {
+        apiKey: (config as any).effectiveApiKey || config.providerSetting.apiKey || '',
         accessKey: config.providerSetting.accessKey || '',
         secretKey: config.providerSetting.secretKey || '',
         sessionToken: config.providerSetting.sessionToken,

--- a/src/shared/providers/definitions/models/bedrock.ts
+++ b/src/shared/providers/definitions/models/bedrock.ts
@@ -1,18 +1,36 @@
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock'
+import { AwsClient } from 'aws4fetch'
 import AbstractAISDKModel, { type CallSettings } from '../../../models/abstract-ai-sdk'
 import type { CallChatCompletionOptions } from '../../../models/types'
 import type { ProviderModelInfo } from '../../../types'
 import type { ModelDependencies } from '../../../types/adapters'
 
 interface Options {
-  accessKey: string
-  secretKey: string
+  apiKey?: string
+  accessKey?: string
+  secretKey?: string
   sessionToken?: string
   region: string
   model: ProviderModelInfo
   temperature?: number
   topP?: number
   maxOutputTokens?: number
+}
+
+interface FoundationModelSummary {
+  modelId: string
+  modelName?: string
+  responseStreamingSupported?: boolean
+  inputModalities?: string[]
+  outputModalities?: string[]
+  modelLifecycle?: { status: string }
+}
+
+interface InferenceProfileSummary {
+  inferenceProfileId: string
+  inferenceProfileName?: string
+  status?: string
+  models?: { modelArn?: string }[]
 }
 
 export default class Bedrock extends AbstractAISDKModel {
@@ -26,6 +44,13 @@ export default class Bedrock extends AbstractAISDKModel {
   }
 
   protected getProvider() {
+    if (this.options.apiKey) {
+      return createAmazonBedrock({
+        region: this.options.region,
+        apiKey: this.options.apiKey,
+      })
+    }
+
     const config: {
       region: string
       accessKeyId: string
@@ -33,8 +58,8 @@ export default class Bedrock extends AbstractAISDKModel {
       sessionToken?: string
     } = {
       region: this.options.region,
-      accessKeyId: this.options.accessKey,
-      secretAccessKey: this.options.secretKey,
+      accessKeyId: this.options.accessKey || '',
+      secretAccessKey: this.options.secretKey || '',
     }
 
     if (this.options.sessionToken) {
@@ -55,5 +80,140 @@ export default class Bedrock extends AbstractAISDKModel {
       topP: this.options.topP,
       maxOutputTokens: this.options.maxOutputTokens,
     }
+  }
+
+  private createFetcher(): (url: string) => Promise<Response> {
+    const region = this.options.region || 'us-east-1'
+    if (this.options.apiKey) {
+      const headers = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.options.apiKey}`,
+      }
+      return (url: string) => fetch(url, { headers })
+    }
+
+    const awsClient = new AwsClient({
+      accessKeyId: this.options.accessKey || '',
+      secretAccessKey: this.options.secretKey || '',
+      sessionToken: this.options.sessionToken,
+      region,
+      service: 'bedrock',
+    })
+    return (url: string) => awsClient.fetch(url)
+  }
+
+  public async listModels(): Promise<ProviderModelInfo[]> {
+    if (!this.options.apiKey && !this.options.accessKey) {
+      return []
+    }
+
+    const region = this.options.region || 'us-east-1'
+    const baseUrl = `https://bedrock.${region}.amazonaws.com`
+    const fetcher = this.createFetcher()
+
+    const [foundationModels, inferenceProfiles] = await Promise.all([
+      this.fetchFoundationModels(baseUrl, fetcher),
+      this.fetchInferenceProfiles(baseUrl, fetcher),
+    ])
+
+    const capabilitiesMap = this.buildCapabilitiesMap(foundationModels)
+
+    return inferenceProfiles
+      .filter((p) => p.status === 'ACTIVE')
+      .map((profile) => {
+        const foundationModelId = this.extractFoundationModelId(profile)
+        const caps = foundationModelId ? capabilitiesMap.get(foundationModelId) : undefined
+
+        const capabilities: ProviderModelInfo['capabilities'] = []
+        if (caps?.hasVision) capabilities.push('vision')
+        if (caps?.hasToolUse) capabilities.push('tool_use')
+
+        return {
+          modelId: profile.inferenceProfileId,
+          nickname: profile.inferenceProfileName || profile.inferenceProfileId,
+          type: 'chat' as const,
+          capabilities,
+          contextWindow: caps?.contextWindow ?? 200_000,
+          maxOutput: caps?.maxOutput ?? 8_192,
+        }
+      })
+  }
+
+  private async fetchFoundationModels(
+    baseUrl: string,
+    fetcher: (url: string) => Promise<Response>
+  ): Promise<FoundationModelSummary[]> {
+    const response = await fetcher(`${baseUrl}/foundation-models`)
+    if (!response.ok) {
+      throw new Error(`Failed to list foundation models: ${response.status}`)
+    }
+    const data = (await response.json()) as { modelSummaries?: FoundationModelSummary[] }
+    return data.modelSummaries ?? []
+  }
+
+  private async fetchInferenceProfiles(
+    baseUrl: string,
+    fetcher: (url: string) => Promise<Response>
+  ): Promise<InferenceProfileSummary[]> {
+    const profiles: InferenceProfileSummary[] = []
+    let nextToken: string | undefined
+
+    do {
+      const url = nextToken
+        ? `${baseUrl}/inference-profiles?maxResults=1000&nextToken=${encodeURIComponent(nextToken)}`
+        : `${baseUrl}/inference-profiles?maxResults=1000`
+
+      const response = await fetcher(url)
+      if (!response.ok) {
+        throw new Error(`Failed to list inference profiles: ${response.status}`)
+      }
+      const data = (await response.json()) as {
+        inferenceProfileSummaries?: InferenceProfileSummary[]
+        nextToken?: string
+      }
+      if (data.inferenceProfileSummaries) {
+        profiles.push(...data.inferenceProfileSummaries)
+      }
+      nextToken = data.nextToken
+    } while (nextToken)
+
+    return profiles
+  }
+
+  private buildCapabilitiesMap(models: FoundationModelSummary[]) {
+    const map = new Map<
+      string,
+      { hasVision: boolean; hasToolUse: boolean; contextWindow: number; maxOutput: number }
+    >()
+
+    for (const model of models) {
+      if (!model.modelId || !model.responseStreamingSupported) continue
+      if (model.modelLifecycle?.status !== 'ACTIVE' && model.modelLifecycle?.status !== 'LEGACY') continue
+
+      const hasVision =
+        (model.inputModalities?.includes('IMAGE') && model.outputModalities?.includes('TEXT')) || false
+      const hasToolUse = model.outputModalities?.includes('TEXT') || false
+
+      let contextWindow = 200_000
+      if (model.modelId.includes('nova')) {
+        contextWindow = 300_000
+      }
+
+      map.set(model.modelId, {
+        hasVision,
+        hasToolUse,
+        contextWindow,
+        maxOutput: 8_192,
+      })
+    }
+
+    return map
+  }
+
+  private extractFoundationModelId(profile: InferenceProfileSummary): string | undefined {
+    const arn = profile.models?.[0]?.modelArn
+    if (!arn) return undefined
+    const match = arn.match(/foundation-model\/(.+)$/)
+    return match?.[1]
   }
 }

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -62,8 +62,8 @@ export const ProviderSettingsSchema = z.object({
 
   // oauth
   oauth: OAuthCredentialsSchema.optional().catch(undefined),
-  /** Which auth method is active: 'apikey' (default) or 'oauth' */
-  activeAuthMode: z.enum(['apikey', 'oauth']).optional().catch(undefined),
+  /** Which auth method is active: 'apikey' (default), 'oauth', or 'iam' (AWS) */
+  activeAuthMode: z.enum(['apikey', 'oauth', 'iam']).optional().catch(undefined),
 
   // azure
   endpoint: z.string().optional().catch(undefined),


### PR DESCRIPTION
## Summary
- **Bedrock API Key authentication**: Add support for the new AWS Bedrock API Key auth method (announced July 2025) as an alternative to IAM credentials. Users can switch between API Key and IAM auth via a segmented control in settings.
- **Dynamic model fetching**: Implement `listModels()` using AWS Bedrock ListFoundationModels + ListInferenceProfiles APIs, enabling automatic model discovery instead of relying solely on hardcoded defaults.
- Both auth methods (API Key and IAM) are supported for model listing via `aws4fetch` SigV4 signing (IAM) or Bearer token (API Key).

## Changes
- `src/shared/providers/definitions/models/bedrock.ts` — Add API Key auth to provider, implement `listModels()` with foundation model capability mapping
- `src/shared/providers/definitions/bedrock.ts` — Pass `effectiveApiKey` to model constructor
- `src/renderer/routes/settings/provider/$providerId.tsx` — Add auth mode toggle UI (API Key vs IAM)
- `src/shared/types/settings.ts` — Add `'iam'` to `activeAuthMode` enum

## Test plan
- [x] Configure Bedrock with API Key auth → verify chat works
- [x] Configure Bedrock with IAM credentials → verify chat works
- [x] Switch between auth modes in settings → verify UI updates correctly
- [x] Click "Check" button with valid credentials → verify model list is fetched
- [x] Verify fetched models show correct capabilities (vision, tool_use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)