### PR TITLE
 fix: avoid Enter submit while composing IME text

### DIFF
--- a/src/renderer/components/InputBox/InputBox.tsx
+++ b/src/renderer/components/InputBox/InputBox.tsx
@@ -76,7 +76,7 @@ import * as chatStore from '@/stores/chatStore'
 import { useSession, useSessionSettings } from '@/stores/chatStore'
 import { settingsStore, useSettingsStore } from '@/stores/settingsStore'
 import { useUIStore } from '@/stores/uiStore'
-import { delay } from '@/utils'
+import { delay, isKeyboardEventComposing } from '@/utils'
 import { featureFlags } from '@/utils/feature-flags'
 import { trackEvent } from '@/utils/track'
 import {
@@ -542,6 +542,10 @@ const InputBox = forwardRef<InputBoxRef, InputBoxProps>(
     )
 
     const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (isKeyboardEventComposing(event)) {
+        return
+      }
+
       const isPressedHash: Record<ShortcutSendValue, boolean> = {
         '': false,
         Enter: event.keyCode === 13 && !event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey,

--- a/src/renderer/modals/AttachLink.tsx
+++ b/src/renderer/modals/AttachLink.tsx
@@ -3,6 +3,7 @@ import { Button, Textarea } from '@mantine/core'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AdaptiveModal } from '@/components/common/AdaptiveModal'
+import { isKeyboardEventComposing } from '@/utils'
 
 const AttachLink = NiceModal.create(() => {
   const modal = useModal()
@@ -25,6 +26,10 @@ const AttachLink = NiceModal.create(() => {
     setInput(e.target.value)
   }
   const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isKeyboardEventComposing(event)) {
+      return
+    }
+
     const ctrlOrCmd = event.ctrlKey || event.metaKey
     // ctrl + enter 提交
     if (event.keyCode === 13 && ctrlOrCmd) {

--- a/src/renderer/modals/MessageEdit.tsx
+++ b/src/renderer/modals/MessageEdit.tsx
@@ -7,6 +7,7 @@ import { AdaptiveModal } from '@/components/common/AdaptiveModal'
 import { AssistantAvatar, SystemAvatar, UserAvatar } from '@/components/common/Avatar'
 import { useIsSmallScreen } from '@/hooks/useScreenChange'
 import { generateMoreInNewFork, modifyMessage } from '@/stores/sessionActions'
+import { isKeyboardEventComposing } from '@/utils'
 
 const MessageEdit = NiceModal.create((props: { sessionId: string; msg: Message; hideSaveAndResend?: boolean }) => {
   const modal = useModal()
@@ -200,6 +201,10 @@ const MessageEditModal = ({
     if (!msg) {
       return
     }
+    if (isKeyboardEventComposing(event)) {
+      return
+    }
+
     const ctrlOrCmd = event.ctrlKey || event.metaKey
     const shift = event.shiftKey
 

--- a/src/renderer/pages/SearchDialog.tsx
+++ b/src/renderer/pages/SearchDialog.tsx
@@ -14,6 +14,7 @@ import { currentSessionIdAtom } from '@/stores/atoms'
 import { useSession } from '@/stores/chatStore'
 import { searchSessions } from '@/stores/sessionHelpers'
 import { useUIStore } from '@/stores/uiStore'
+import { isKeyboardEventComposing } from '@/utils'
 import * as scrollActions from '../stores/scrollActions'
 import { switchCurrentSession } from '../stores/sessionActions'
 
@@ -65,6 +66,10 @@ export default function SearchDialog(props: Props) {
     ref.current?.select() // 搜索后全选输入框，方便删除回退
   }
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (isKeyboardEventComposing(e)) {
+      return
+    }
+
     if (globalOnly && e.key === 'Enter' && searchInput.trim()) {
       e.preventDefault()
       onSearchClick('global')

--- a/src/renderer/routes/copilots/-components/ExpandableSearch.tsx
+++ b/src/renderer/routes/copilots/-components/ExpandableSearch.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScalableIcon } from '@/components/common/ScalableIcon'
 import { useIsSmallScreen } from '@/hooks/useScreenChange'
+import { isKeyboardEventComposing } from '@/utils'
 
 export interface ExpandableSearchProps {
   onSearch: (term: string) => void
@@ -26,7 +27,11 @@ export function ExpandableSearch({ onSearch }: ExpandableSearchProps) {
     setValue(e.currentTarget.value)
   }
 
-  const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (isKeyboardEventComposing(e)) {
+      return
+    }
+
     if (e.key === 'Enter') {
       handleSearch()
     }
@@ -60,7 +65,7 @@ export function ExpandableSearch({ onSearch }: ExpandableSearchProps) {
               placeholder={t('Search copilots...') ?? ''}
               value={value}
               onChange={handleChange}
-              onKeyUp={handleKeyUp}
+              onKeyDown={handleKeyDown}
               onBlur={handleBlur}
               size="xs"
               w={isSmallScreen ? 160 : 200}

--- a/src/renderer/routes/image-creator/index.tsx
+++ b/src/renderer/routes/image-creator/index.tsx
@@ -9,17 +9,16 @@ import {
   Stack,
   Text,
   Textarea,
-  Tooltip,
   UnstyledButton,
 } from '@mantine/core'
 import type { ImageGeneration } from '@shared/types'
 import { ModelProviderEnum, ModelProviderType } from '@shared/types'
 import {
+  IconArrowUp,
   IconAspectRatio,
   IconChevronRight,
   IconHistory,
   IconPhoto,
-  IconArrowUp,
   IconPlus,
   IconSparkles,
 } from '@tabler/icons-react'
@@ -46,6 +45,7 @@ import {
 import { queryClient } from '@/stores/queryClient'
 import { settingsStore } from '@/stores/settingsStore'
 import * as toastActions from '@/stores/toastActions'
+import { isKeyboardEventComposing } from '@/utils'
 import {
   CHATBOXAI_IMAGE_MODEL_IDS,
   GEMINI_IMAGE_MODEL_IDS,
@@ -639,6 +639,10 @@ function ImageCreatorPage() {
                         },
                       }}
                       onKeyDown={(e) => {
+                        if (isKeyboardEventComposing(e)) {
+                          return
+                        }
+
                         if (e.key === 'Enter' && !e.shiftKey) {
                           e.preventDefault()
                           void handleSubmit()

--- a/src/renderer/utils/index.test.ts
+++ b/src/renderer/utils/index.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { isKeyboardEventComposing } from './index'
+
+describe('isKeyboardEventComposing', () => {
+  it('detects native composition events', () => {
+    expect(isKeyboardEventComposing({ nativeEvent: { isComposing: true }, keyCode: 13 })).toBe(true)
+  })
+
+  it('detects browser IME keyCode fallback', () => {
+    expect(isKeyboardEventComposing({ keyCode: 229 })).toBe(true)
+  })
+
+  it('allows normal Enter key events', () => {
+    expect(isKeyboardEventComposing({ nativeEvent: { isComposing: false }, keyCode: 13 })).toBe(false)
+  })
+})

--- a/src/renderer/utils/index.ts
+++ b/src/renderer/utils/index.ts
@@ -3,3 +3,15 @@ export function delay(ms: number): Promise<void> {
     setTimeout(resolve, ms)
   })
 }
+
+type KeyboardEventWithComposition = {
+  nativeEvent?: {
+    isComposing?: boolean
+  }
+  keyCode?: number
+}
+
+export function isKeyboardEventComposing(event: KeyboardEventWithComposition): boolean {
+  // Some browsers report keyCode 229 while an IME owns the key event.
+  return event.nativeEvent?.isComposing === true || event.keyCode === 229
+}


### PR DESCRIPTION
## Summary

  - Add a shared helper to detect IME composition keyboard events.
  - Prevent Enter/Cmd+Enter based submit actions while users are composing text with IME.
  - Apply the guard to chat input, image prompt input, search inputs, link attachment, and message editing.
  - Add unit tests for native `isComposing` and `keyCode === 229` fallback.

  ## Test

  - pnpm exec vitest run src/renderer/utils/index.test.ts
  - Manual test with Chinese IME: pressing Enter to select a candidate no longer submits the message.
