### PR TITLE
feat: MCP Server Presets + Bulk Import — curated popular servers & JSON import

### DIFF
--- a/src/renderer/components/settings/mcp/McpBulkImport.tsx
+++ b/src/renderer/components/settings/mcp/McpBulkImport.tsx
@@ -1,0 +1,146 @@
+import { Button, Stack, Text, Textarea, Alert, Group, Badge, Flex } from '@mantine/core'
+import { IconUpload, IconServer } from '@tabler/icons-react'
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AdaptiveModal } from '@/components/common/AdaptiveModal'
+import { ScalableIcon } from '@/components/common/ScalableIcon'
+
+interface McpBulkImportProps {
+    opened: boolean
+    onClose: () => void
+    onImport: (servers: Record<string, any>) => void
+    existingServerNames: string[]
+}
+
+export function McpBulkImport({ opened, onClose, onImport, existingServerNames }: McpBulkImportProps) {
+    const { t } = useTranslation()
+    const [input, setInput] = useState('')
+    const [error, setError] = useState<string | null>(null)
+    const [parsedServers, setParsedServers] = useState<Record<string, any>>({})
+
+    const handleParse = useCallback(() => {
+        setError(null)
+        try {
+            const parsed = JSON.parse(input.trim())
+            if (typeof parsed !== 'object' || parsed === null) {
+                setError(t('Expected a JSON object with server names as keys'))
+                return
+            }
+            // Validate each server config
+            const valid: Record<string, any> = {}
+            for (const [name, config] of Object.entries(parsed)) {
+                if (typeof config !== 'object' || config === null) continue
+                const cfg = config as any
+                if (!cfg.transport || !['stdio', 'sse', 'streamable-http'].includes(cfg.transport)) continue
+                if (cfg.transport === 'stdio' && !cfg.command) continue
+                if ((cfg.transport === 'sse' || cfg.transport === 'streamable-http') && !cfg.url) continue
+                valid[name] = cfg
+            }
+            if (Object.keys(valid).length === 0) {
+                setError(t('No valid server configurations found'))
+                return
+            }
+            setParsedServers(valid)
+        } catch (e: any) {
+            setError(t('Invalid JSON: {{error}}', { error: e.message }))
+        }
+    }, [input, t])
+
+    const handleImport = useCallback(() => {
+        const newServers: Record<string, any> = {}
+        for (const [name, config] of Object.entries(parsedServers)) {
+            if (!existingServerNames.includes(name)) {
+                newServers[name] = config
+            }
+        }
+        if (Object.keys(newServers).length > 0) {
+            onImport(newServers)
+        }
+        setInput('')
+        setParsedServers({})
+        onClose()
+    }, [parsedServers, existingServerNames, onImport, onClose])
+
+    const serverNames = Object.keys(parsedServers)
+    const newServers = serverNames.filter(n => !existingServerNames.includes(n))
+    const duplicates = serverNames.filter(n => existingServerNames.includes(n))
+
+    return (
+        <AdaptiveModal
+            opened={opened}
+            onClose={() => { setInput(''); setParsedServers({}); setError(null); onClose() }}
+            title={t('Import MCP Servers')}
+            centered
+            size="lg"
+        >
+            <Stack gap="md">
+                <Text size="sm" c="chatbox-secondary">
+                    {t('Paste a JSON object containing MCP server configurations. Keys are server names, values are server configs.')}
+                </Text>
+
+                <Textarea
+                    value={input}
+                    onChange={(e) => setInput(e.currentTarget.value)}
+                    placeholder={`{\n  "my-server": {\n    "transport": "stdio",\n    "command": "npx",\n    "args": ["-y", "@my-org/mcp-server"]\n  },\n  "remote-server": {\n    "transport": "sse",\n    "url": "http://localhost:3001/sse"\n  }\n}`}
+                    minRows={8}
+                    maxRows={16}
+                    styles={{ input: { fontFamily: 'monospace', fontSize: '13px' } }}
+                />
+
+                <Button
+                    variant="light"
+                    onClick={handleParse}
+                    disabled={!input.trim()}
+                    leftSection={<ScalableIcon icon={IconUpload} size={16} />}
+                    size="compact-sm"
+                >
+                    {t('Parse & Preview')}
+                </Button>
+
+                {error && <Alert color="red" variant="light">{error}</Alert>}
+
+                {serverNames.length > 0 && (
+                    <>
+                        <Text size="sm" fw={600}>
+                            {t('Preview')} ({newServers.length} {t('new')}, {duplicates.length} {t('duplicates')})
+                        </Text>
+                        <Stack gap="xs">
+                            {serverNames.map(name => {
+                                const cfg = parsedServers[name] as any
+                                const isDupe = existingServerNames.includes(name)
+                                return (
+                                    <Flex key={name} justify="space-between" align="center" p="xs"
+                                        style={{
+                                            borderRadius: 4,
+                                            backgroundColor: isDupe ? 'var(--mantine-color-yellow-light)' : 'var(--mantine-color-default-hover)',
+                                            opacity: isDupe ? 0.6 : 1,
+                                        }}>
+                                        <Flex align="center" gap="sm">
+                                            <ScalableIcon icon={IconServer} size={16} />
+                                            <Text size="sm" fw={500}>{name}</Text>
+                                            <Badge size="xs" variant="outline">{cfg.transport}</Badge>
+                                            <Text size="xs" c="chatbox-tertiary" style={{ fontFamily: 'monospace' }}>
+                                                {cfg.transport === 'stdio' ? cfg.command : cfg.url}
+                                            </Text>
+                                        </Flex>
+                                        {isDupe && <Badge size="xs" color="yellow">{t('exists')}</Badge>}
+                                    </Flex>
+                                )
+                            })}
+                        </Stack>
+                    </>
+                )}
+
+                <Group justify="flex-end">
+                    <Button variant="default" onClick={() => { setInput(''); setParsedServers({}); setError(null); onClose() }}>
+                        {t('Cancel')}
+                    </Button>
+                    <Button onClick={handleImport} disabled={newServers.length === 0}
+                        leftSection={<ScalableIcon icon={IconServer} size={16} />}>
+                        {t('Import')} {newServers.length > 0 ? `${newServers.length} ${t('Servers')}` : ''}
+                    </Button>
+                </Group>
+            </Stack>
+        </AdaptiveModal>
+    )
+}

--- a/src/renderer/components/settings/mcp/McpServerPresets.tsx
+++ b/src/renderer/components/settings/mcp/McpServerPresets.tsx
@@ -1,0 +1,310 @@
+import { Button, Flex, Stack, Text, Group, Badge, TextInput, Collapse, ActionIcon, Tooltip, Alert } from '@mantine/core'
+import { IconServer, IconPlus, IconSearch, IconChevronDown, IconChevronRight, IconClipboard, IconCheck } from '@tabler/icons-react'
+import { useCallback, useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ScalableIcon } from '@/components/common/ScalableIcon'
+
+export interface McpServerPreset {
+    id: string
+    name: string
+    description: string
+    category: string
+    transport: 'stdio' | 'sse' | 'streamable-http'
+    config: {
+        command?: string
+        args?: string[]
+        url?: string
+        env?: Record<string, string>
+    }
+    tags: string[]
+    popularity: number
+}
+
+const MCP_SERVER_PRESETS: McpServerPreset[] = [
+    {
+        id: 'filesystem',
+        name: 'Filesystem',
+        description: 'Secure file operations with configurable access controls. Read, write, and manage files.',
+        category: 'File & Storage',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem', '/path/to/allowed/dir'] },
+        tags: ['files', 'storage', 'official'],
+        popularity: 100,
+    },
+    {
+        id: 'github',
+        name: 'GitHub',
+        description: 'Repository management, file operations, and GitHub API integration.',
+        category: 'Development',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-github'], env: { GITHUB_PERSONAL_ACCESS_TOKEN: '<your-token>' } },
+        tags: ['git', 'github', 'development', 'official'],
+        popularity: 95,
+    },
+    {
+        id: 'brave-search',
+        name: 'Brave Search',
+        description: 'Web and local search using Brave Search API.',
+        category: 'Search & Web',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-brave-search'], env: { BRAVE_API_KEY: '<your-api-key>' } },
+        tags: ['search', 'web', 'official'],
+        popularity: 90,
+    },
+    {
+        id: 'postgres',
+        name: 'PostgreSQL',
+        description: 'Read-only database access with schema inspection. Query PostgreSQL databases.',
+        category: 'Database',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-postgres', 'postgresql://localhost/mydb'] },
+        tags: ['database', 'sql', 'postgres', 'official'],
+        popularity: 85,
+    },
+    {
+        id: 'sqlite',
+        name: 'SQLite',
+        description: 'Database interaction and business intelligence. Query and analyze SQLite databases.',
+        category: 'Database',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-sqlite', '--db-path', '/path/to/database.db'] },
+        tags: ['database', 'sql', 'sqlite', 'official'],
+        popularity: 85,
+    },
+    {
+        id: 'memory',
+        name: 'Memory (Knowledge Graph)',
+        description: 'Persistent memory using a knowledge graph. Remember facts and relationships across sessions.',
+        category: 'Knowledge',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-memory'] },
+        tags: ['memory', 'knowledge', 'graph', 'official'],
+        popularity: 80,
+    },
+    {
+        id: 'puppeteer',
+        name: 'Puppeteer',
+        description: 'Browser automation and web scraping. Navigate pages, take screenshots, execute JavaScript.',
+        category: 'Browser & Automation',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-puppeteer'] },
+        tags: ['browser', 'automation', 'scraping', 'official'],
+        popularity: 80,
+    },
+    {
+        id: 'fetch',
+        name: 'Fetch',
+        description: 'Web content fetching and conversion. Retrieve and process web pages.',
+        category: 'Search & Web',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-fetch'] },
+        tags: ['web', 'fetch', 'http', 'official'],
+        popularity: 75,
+    },
+    {
+        id: 'everything',
+        name: 'Everything (Reference)',
+        description: 'Reference/test server with prompts, resources, and tools. Great for testing MCP clients.',
+        category: 'Testing',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-everything'] },
+        tags: ['test', 'reference', 'demo', 'official'],
+        popularity: 60,
+    },
+    {
+        id: 'sequential-thinking',
+        name: 'Sequential Thinking',
+        description: 'Dynamic problem-solving through thought sequences. Structured reasoning tool.',
+        category: 'Reasoning',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-sequential-thinking'] },
+        tags: ['thinking', 'reasoning', 'official'],
+        popularity: 70,
+    },
+    {
+        id: 'mcp-installer',
+        name: 'MCP Installer',
+        description: 'Install and manage other MCP servers. One-click install from npm.',
+        category: 'Utility',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', '@anaisbetts/mcp-installer'] },
+        tags: ['installer', 'manager', 'utility'],
+        popularity: 65,
+    },
+    {
+        id: 'tavily',
+        name: 'Tavily AI Search',
+        description: 'AI-optimized web search via Tavily API.',
+        category: 'Search & Web',
+        transport: 'stdio',
+        config: { command: 'npx', args: ['-y', 'tavily-mcp@0.1.4'], env: { TAVILY_API_KEY: '<your-api-key>' } },
+        tags: ['search', 'ai', 'web'],
+        popularity: 75,
+    },
+]
+
+const CATEGORIES = [...new Set(MCP_SERVER_PRESETS.map(p => p.category))].sort()
+
+interface McpServerPresetsProps {
+    onAddServer: (name: string, config: any) => void
+    existingServerNames: string[]
+}
+
+export function McpServerPresets({ onAddServer, existingServerNames }: McpServerPresetsProps) {
+    const { t } = useTranslation()
+    const [search, setSearch] = useState('')
+    const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+    const [expandedId, setExpandedId] = useState<string | null>(null)
+    const [copiedId, setCopiedId] = useState<string | null>(null)
+
+    const filtered = useMemo(() => {
+        return MCP_SERVER_PRESETS
+            .filter(p => {
+                if (selectedCategory && p.category !== selectedCategory) return false
+                if (search) {
+                    const q = search.toLowerCase()
+                    return p.name.toLowerCase().includes(q)
+                        || p.description.toLowerCase().includes(q)
+                        || p.tags.some(t => t.includes(q))
+                }
+                return true
+            })
+            .sort((a, b) => b.popularity - a.popularity)
+    }, [search, selectedCategory])
+
+    const handleAdd = useCallback((preset: McpServerPreset) => {
+        onAddServer(preset.name.toLowerCase().replace(/\s+/g, '-'), {
+            transport: preset.transport,
+            ...preset.config,
+        })
+    }, [onAddServer])
+
+    const handleCopyConfig = useCallback((preset: McpServerPreset) => {
+        const config = JSON.stringify({ [preset.name.toLowerCase().replace(/\s+/g, '-')]: {
+            transport: preset.transport,
+            ...preset.config,
+        }}, null, 2)
+        navigator.clipboard.writeText(config).then(() => {
+            setCopiedId(preset.id)
+            setTimeout(() => setCopiedId(null), 2000)
+        })
+    }, [])
+
+    return (
+        <Stack gap="md">
+            <Flex justify="space-between" align="center">
+                <Flex align="center" gap="xs">
+                    <ScalableIcon icon={IconServer} size={18} />
+                    <Text fw={600}>{t('MCP Server Presets')}</Text>
+                    <Badge size="sm" variant="light">{MCP_SERVER_PRESETS.length}</Badge>
+                </Flex>
+            </Flex>
+
+            <Text size="sm" c="chatbox-secondary">
+                {t('Popular MCP servers you can add with one click. Requires Node.js (npx) to be installed.')}
+            </Text>
+
+            <TextInput
+                placeholder={t('Search servers...')}
+                leftSection={<ScalableIcon icon={IconSearch} size={16} />}
+                value={search}
+                onChange={(e) => setSearch(e.currentTarget.value)}
+                size="sm"
+            />
+
+            <Flex gap="xs" wrap="wrap">
+                <Badge
+                    size="sm"
+                    variant={selectedCategory === null ? 'filled' : 'light'}
+                    style={{ cursor: 'pointer' }}
+                    onClick={() => setSelectedCategory(null)}
+                >
+                    {t('All')}
+                </Badge>
+                {CATEGORIES.map(cat => (
+                    <Badge
+                        key={cat}
+                        size="sm"
+                        variant={selectedCategory === cat ? 'filled' : 'light'}
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => setSelectedCategory(selectedCategory === cat ? null : cat)}
+                    >
+                        {cat}
+                    </Badge>
+                ))}
+            </Flex>
+
+            <Stack gap="xs" style={{ maxHeight: 400, overflow: 'auto' }}>
+                {filtered.map((preset) => {
+                    const isExpanded = expandedId === preset.id
+                    const isAdded = existingServerNames.includes(preset.name.toLowerCase().replace(/\s+/g, '-'))
+                    return (
+                        <Stack key={preset.id} gap={0}
+                            style={{
+                                border: '1px solid var(--mantine-color-chatbox-border-secondary)',
+                                borderRadius: 8,
+                                overflow: 'hidden',
+                            }}>
+                            <Flex justify="space-between" align="center" p="sm"
+                                style={{ cursor: 'pointer' }}
+                                onClick={() => setExpandedId(isExpanded ? null : preset.id)}>
+                                <Flex align="center" gap="sm" style={{ flex: 1, minWidth: 0 }}>
+                                    <ScalableIcon
+                                        icon={isExpanded ? IconChevronDown : IconChevronRight}
+                                        size={14}
+                                        color="var(--mantine-color-chatbox-tertiary)"
+                                    />
+                                    <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
+                                        <Flex align="center" gap="xs">
+                                            <Text size="sm" fw={500}>{preset.name}</Text>
+                                            <Badge size="xs" variant="outline" color="gray">{preset.transport}</Badge>
+                                        </Flex>
+                                        <Text size="xs" c="chatbox-tertiary" lineClamp={1}>{preset.description}</Text>
+                                    </Stack>
+                                </Flex>
+                                <Flex gap="xs">
+                                    <Tooltip label={t('Copy config')}>
+                                        <ActionIcon variant="subtle" size="sm"
+                                            onClick={(e) => { e.stopPropagation(); handleCopyConfig(preset) }}>
+                                            <ScalableIcon
+                                                icon={copiedId === preset.id ? IconCheck : IconClipboard}
+                                                size={14}
+                                                color={copiedId === preset.id ? 'var(--mantine-color-green-filled)' : undefined}
+                                            />
+                                        </ActionIcon>
+                                    </Tooltip>
+                                    <Button
+                                        variant="light"
+                                        size="compact-xs"
+                                        disabled={isAdded}
+                                        leftSection={<ScalableIcon icon={IconPlus} size={12} />}
+                                        onClick={(e) => { e.stopPropagation(); handleAdd(preset) }}
+                                    >
+                                        {isAdded ? t('Added') : t('Add')}
+                                    </Button>
+                                </Flex>
+                            </Flex>
+                            <Collapse in={isExpanded}>
+                                <Stack gap="xs" px="sm" pb="sm"
+                                    style={{ borderTop: '1px solid var(--mantine-color-chatbox-border-secondary)' }}>
+                                    <Text size="xs" pt="sm">{preset.description}</Text>
+                                    <Flex gap="xs" wrap="wrap">
+                                        {preset.tags.map(tag => (
+                                            <Badge key={tag} size="xs" variant="dot">{tag}</Badge>
+                                        ))}
+                                    </Flex>
+                                    <Stack gap={2}>
+                                        <Text size="xs" fw={500} c="chatbox-secondary">Config:</Text>
+                                        <Text size="xs" style={{ fontFamily: 'monospace', whiteSpace: 'pre-wrap', backgroundColor: 'var(--mantine-color-default-hover)', padding: 4, borderRadius: 4 }}>
+                                            {JSON.stringify(preset.config, null, 2)}
+                                        </Text>
+                                    </Stack>
+                                </Stack>
+                            </Collapse>
+                        </Stack>
+                    )
+                })}
+            </Stack>
+        </Stack>
+    )
+}


### PR DESCRIPTION
## Summary

Enhances the MCP custom server experience with two new features:

### 1. MCP Server Presets

A curated list of **12 popular MCP servers** that users can browse, search, and one-click add:

| Server | Category | Transport |
|--------|----------|-----------|
| Filesystem | File & Storage | stdio |
| GitHub | Development | stdio |
| Brave Search | Search & Web | stdio |
| PostgreSQL | Database | stdio |
| SQLite | Database | stdio |
| Memory (Knowledge Graph) | Knowledge | stdio |
| Puppeteer | Browser & Automation | stdio |
| Fetch | Search & Web | stdio |
| Sequential Thinking | Reasoning | stdio |
| MCP Installer | Utility | stdio |
| Tavily AI Search | Search & Web | stdio |
| Everything (Reference) | Testing | stdio |

Features:
- Category filtering and text search
- Expandable cards with full config preview
- One-click copy config to clipboard
- One-click add (with duplicate detection)
- Popularity-sorted

### 2. MCP Bulk Import

Import multiple MCP server configurations from a single JSON object:
```json
{
  "my-server": {"transport": "stdio", "command": "npx", "args": ["-y", "@my-org/mcp-server"]},
  "remote-server": {"transport": "sse", "url": "http://localhost:3001/sse"}
}
```

### Files Changed

| File | Description |
|------|-------------|
| `src/renderer/components/settings/mcp/McpServerPresets.tsx` | Server presets browser |
| `src/renderer/components/settings/mcp/McpBulkImport.tsx` | JSON bulk import modal |

### Note

These are **standalone components** that can be integrated into the existing MCP settings page (`CustomServersSection`). They don't modify existing code — just add new UI components ready to be wired up.
