### PR TITLE
fix(store-node): surface permission errors from setStoreBlob/delStoreBlob

### DIFF
--- a/src/main/store-node.test.ts
+++ b/src/main/store-node.test.ts
@@ -1,0 +1,132 @@
+// Regression test for src/main/store-node.ts setStoreBlob / delStoreBlob.
+//
+// Verifies that fs-extra permission failures (EACCES on ensureDir, EACCES on remove)
+// surface as actionable errors with the original errno preserved as `cause`, instead of
+// crossing the IPC boundary as an opaque "An object could not be cloned" error.
+//
+// Note: this is the first test in src/main/. The vitest config (vitest.config.ts L13)
+// already includes `src/**/*.{test,spec}.{ts,tsx}` so no config change is needed.
+// We mock 'electron' (app.getPath) and 'fs-extra' so the test does not require an
+// Electron runtime or actual filesystem access.
+
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => `/tmp/chatbox-test-userdata/${name}`,
+  },
+  powerMonitor: {
+    on: vi.fn(),
+  },
+}))
+
+vi.mock('fs-extra', () => {
+  const mock = {
+    existsSync: vi.fn().mockReturnValue(false),
+    readdirSync: vi.fn().mockReturnValue([]),
+    ensureDir: vi.fn(),
+    writeFile: vi.fn(),
+    remove: vi.fn(),
+    pathExists: vi.fn(),
+    readFile: vi.fn(),
+    readFileSync: vi.fn(),
+    copy: vi.fn(),
+    copySync: vi.fn(),
+  }
+  return { ...mock, default: mock }
+})
+
+vi.mock('./util', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+describe('store-node blob storage', () => {
+  let storeNode: typeof import('./store-node.js')
+  let fs: typeof import('fs-extra')
+
+  beforeEach(async () => {
+    vi.resetModules()
+    fs = (await import('fs-extra')) as unknown as typeof import('fs-extra')
+    storeNode = await import('./store-node.js')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('setStoreBlob', () => {
+    it('writes successfully when the userData dir is writable', async () => {
+      ;(fs.ensureDir as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
+      ;(fs.writeFile as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
+
+      await expect(storeNode.setStoreBlob('parseFile-abc', 'hello world')).resolves.toBeUndefined()
+
+      expect(fs.ensureDir).toHaveBeenCalledWith(
+        path.resolve('/tmp/chatbox-test-userdata/userData', 'chatbox-blobs')
+      )
+      expect(fs.writeFile).toHaveBeenCalled()
+    })
+
+    it('surfaces EACCES from ensureDir as a permission error with cause preserved', async () => {
+      const eacces = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+      ;(fs.ensureDir as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(eacces)
+
+      await expect(storeNode.setStoreBlob('parseFile-abc', 'x')).rejects.toThrow(
+        /permission denied.*chatbox userData directory is writable/i
+      )
+      // The original errno error must be preserved as `cause` so the renderer's
+      // Sentry handler reports the actionable detail (code=EACCES + path).
+      try {
+        await storeNode.setStoreBlob('parseFile-abc', 'x')
+      } catch (e) {
+        expect((e as Error & { cause?: { code?: string } }).cause?.code).toBe('EACCES')
+      }
+    })
+
+    it('surfaces EROFS (read-only filesystem) the same way', async () => {
+      const erofs = Object.assign(new Error('EROFS: read-only file system'), { code: 'EROFS' })
+      ;(fs.ensureDir as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(erofs)
+
+      await expect(storeNode.setStoreBlob('k', 'v')).rejects.toThrow(/permission denied/i)
+    })
+
+    it('rethrows non-permission errors unchanged', async () => {
+      const enospc = Object.assign(new Error('ENOSPC: no space left'), { code: 'ENOSPC' })
+      ;(fs.ensureDir as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
+      ;(fs.writeFile as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(enospc)
+
+      await expect(storeNode.setStoreBlob('k', 'v')).rejects.toBe(enospc)
+    })
+  })
+
+  describe('delStoreBlob', () => {
+    it('returns silently when the file does not exist (existing behaviour preserved)', async () => {
+      ;(fs.pathExists as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false)
+
+      await expect(storeNode.delStoreBlob('missing')).resolves.toBeUndefined()
+      expect(fs.remove).not.toHaveBeenCalled()
+    })
+
+    it('swallows ENOENT from remove (race between pathExists and remove)', async () => {
+      ;(fs.pathExists as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true)
+      const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      ;(fs.remove as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(enoent)
+
+      await expect(storeNode.delStoreBlob('vanished')).resolves.toBeUndefined()
+    })
+
+    it('rethrows EACCES so callers can surface a permission failure', async () => {
+      ;(fs.pathExists as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true)
+      const eacces = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+      ;(fs.remove as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(eacces)
+
+      await expect(storeNode.delStoreBlob('locked')).rejects.toBe(eacces)
+    })
+  })
+})

--- a/src/main/store-node.ts
+++ b/src/main/store-node.ts
@@ -229,8 +229,21 @@ export async function getStoreBlob(key: string) {
 
 export async function setStoreBlob(key: string, value: string) {
   const filename = path.resolve(app.getPath('userData'), 'chatbox-blobs', sanitizeFilename(key))
-  await fs.ensureDir(path.dirname(filename))
-  return fs.writeFile(filename, value, { encoding: 'utf-8' })
+  try {
+    await fs.ensureDir(path.dirname(filename))
+    return await fs.writeFile(filename, value, { encoding: 'utf-8' })
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code
+    logger.error(`setStoreBlob failed for key="${key}" (code=${code}):`, err)
+    if (code === 'EACCES' || code === 'EPERM' || code === 'EROFS') {
+      throw new Error(
+        `Cannot write attachment cache to "${path.dirname(filename)}": permission denied. ` +
+          `Check that the chatbox userData directory is writable.`,
+        { cause: err }
+      )
+    }
+    throw err
+  }
 }
 
 export async function delStoreBlob(key: string) {
@@ -239,7 +252,17 @@ export async function delStoreBlob(key: string) {
   if (!exists) {
     return
   }
-  await fs.remove(filename)
+  try {
+    await fs.remove(filename)
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code
+    if (code === 'ENOENT') {
+      // Race: file vanished between pathExists() and remove(). Safe to ignore.
+      return
+    }
+    logger.error(`delStoreBlob failed for key="${key}" (code=${code}):`, err)
+    throw err
+  }
 }
 
 export async function listStoreBlobKeys() {


### PR DESCRIPTION
### Description

When a user attaches a file (PDF, DOCX, EPUB, pasted long text, etc.) to a chat, chatbox parses the content in the renderer and persists the parsed text to disk via the IPC handler `setStoreBlob` → `src/main/store-node.ts:230`. Today, if the userData blob directory is unwritable — corporate-managed macOS profile, Windows running chatbox under a non-admin service account, AppData on a network share that disconnected, full-disk-encrypted volume locked, etc. — `fs.ensureDir(...)` rejects with `EACCES`/`EPERM`/`EROFS`, the rejection bubbles through the unhandled `ipcMain.handle('setStoreBlob', ...)` callback at `src/main/main.ts:547`, and Electron stringifies it across the IPC boundary as the unhelpful generic `Error: An object could not be cloned`. The user sees a silently-dropped attachment with no actionable feedback; Sentry receives only the post-IPC opaque error.

This PR wraps both `setStoreBlob` and `delStoreBlob` in `try`/`catch` blocks that match the existing pattern used elsewhere in the same file (`autoBackup` at L54-66, `backup()` at L96-101, `clearBackups()` at L192-204 — all use `try { ... } catch (err) { logger.error('...', err) }`). The catch:

- Logs `code` + the original error via the existing `logger.error(...)` so `electron-log` captures the actionable detail.
- Translates permission errors (`EACCES` / `EPERM` / `EROFS`) into a clear `Error("Cannot write attachment cache to '<path>': permission denied. Check that the chatbox userData directory is writable.", { cause: err })`. Node's `Error.cause` (≥16.9, well within chatbox's pinned `engines.node: ">=20.0.0 <23.0.0"`) preserves the original errno + path so the renderer's existing Sentry handler (`src/renderer/setup/global_error_handler.ts`, documented in `ERROR_HANDLING.md`) reports both layers.
- Re-throws all non-permission errors unchanged (preserves existing observability for `ENOSPC`, `EIO`, etc.).
- For `delStoreBlob`, swallows `ENOENT` (race between the existing `pathExists()` pre-check and `remove()` is now explicitly idempotent) but surfaces `EACCES`/`EPERM` so genuine permission failures don't leave orphaned cache entries silently.

### Additional Notes

- **First test for `src/main/**`.** `src/main/` had no existing test coverage. The new `src/main/store-node.test.ts` mocks `electron` (`app.getPath`) and `fs-extra` so the suite runs under the existing `pnpm exec vitest run` invocation without needing an Electron runtime. The vitest config (`vitest.config.ts` L13) already globs `src/**/*.{test,spec}.{ts,tsx}` — no config change required. 7 tests, all green.
- **No behaviour change on the happy path.** `setStoreBlob` still returns the `fs.writeFile` result; `delStoreBlob` still returns `undefined` when the file is absent or successfully removed. The only observable change is what surfaces when the disk write fails.
- **Conforms to existing `try { ... } catch (err) { logger.error(...) }` style** used by `autoBackup` (L54), `backup()` (L96), and `clearBackups()` (L192-204) in the same file — no new convention introduced.
- **Surgical scope.** +26 / -3 lines in one source file. Happy to extend the same pattern to `getStoreBlob` / `listStoreBlobKeys` (read paths) in a follow-up if you'd like, though their failure modes are already more user-actionable (read failures already propagate the original `Error` rather than getting opaqued by IPC stringification of an awaited rejection).

### Screenshots

_N/A — backend/IPC change with no UI surface._

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[x] I have read and agree with the above statement.
