### PR TITLE
Refresh README layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,69 @@
   <a href="./doc/README-CN.md">简体中文</a>
 </p>
 
+<h1 align="center">
+<img src='./doc/statics/icon.png' width='30'>
+<span>
+    Chatbox
+    <span style="font-size:8px; font-weight: normal;">(Community Edition)</span>
+</span>
+</h1>
+<p align="center">
+    <em>Your Ultimate AI Copilot on the Desktop. <br />Chatbox is a desktop client for ChatGPT, Claude and other LLMs, available on Windows, Mac, Linux</em>
+</p>
+
+<p align="center">
+<a href="https://github.com/chatboxai/chatbox/releases" target="_blank">
+<img alt="macOS" src="https://img.shields.io/badge/-macOS-black?style=flat-square&logo=apple&logoColor=white" />
+</a>
+<a href="https://github.com/chatboxai/chatbox/releases" target="_blank">
+<img alt="Windows" src="https://img.shields.io/badge/-Windows-blue?style=flat-square&logo=windows&logoColor=white" />
+</a>
+<a href="https://github.com/chatboxai/chatbox/releases" target="_blank">
+<img alt="Linux" src="https://img.shields.io/badge/-Linux-yellow?style=flat-square&logo=linux&logoColor=white" />
+</a>
+<a href="https://github.com/chatboxai/chatbox/releases" target="_blank">
+<img alt="Downloads" src="https://img.shields.io/github/downloads/chatboxai/chatbox/total.svg?style=flat" />
+</a>
+<a href="#features">
+<img alt="Privacy" src="https://img.shields.io/badge/-Local%20First-green?style=flat-square&logo=shield&logoColor=white" />
+</a>
+</p>
+
+<p align="center">
+<a href="https://www.producthunt.com/posts/chatbox?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-chatbox" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=429547&theme=light" alt="Chatbox - Better&#0032;UI&#0032;&#0038;&#0032;Desktop&#0032;App&#0032;for&#0032;ChatGPT&#0044;&#0032;Claude&#0032;and&#0032;other&#0032;LLMs&#0046; | Product Hunt" style="width: 150px; height: 30px;" width="100" height="40" /></a>
+<a href="https://trendshift.io/repositories/14871" target="_blank"><img src="https://trendshift.io/api/badge/repositories/14871" alt="chatboxai%2Fchatbox | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
+
+<p align="center">
+  <a href="./doc/statics/snapshot_light.png">
+    <img src="./doc/statics/snapshot_light.png" width="400"/>
+  </a>
+  <a href="./doc/statics/snapshot_dark.png">
+    <img src="./doc/statics/snapshot_dark.png" width="400"/>
+  </a>
+</p>
+
+<div align="center" markdown="1">
+  <a href="https://go.warp.dev/chatbox">
+    <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/refs/heads/main/Github/Sponsor/Warp-Github-LG-02.png">
+  </a>
+
+### [Warp, built for coding with multiple AI agents.](https://go.warp.dev/chatbox)
+[Available for MacOS, Linux, & Windows](https://go.warp.dev/chatbox)<br>
+</div>
+
+---
+
 This is the repository for the Chatbox Community Edition, open-sourced under the GPLv3 license.
 
 [Chatbox is going open-source Again!](https://github.com/chatboxai/chatbox/issues/2266)
 
 We regularly sync code from the pro repo to this repo, and vice versa.
 
-### Download for Desktop
+## Download
+
+### Desktop
 
 <table style="width: 100%">
   <tr>
@@ -55,7 +111,7 @@ We regularly sync code from the pro repo to this repo, and vice versa.
   </tr>
 </table>
 
-### Download for iOS/Android
+### iOS/Android
 
 <a href='https://apps.apple.com/app/chatbox-ai/id6471368056' style='margin-right: 4px'>
 <img src='./doc/statics/app_store.webp' style="height:38px;" />
@@ -85,56 +141,6 @@ For more information: [chatboxai.app](https://chatboxai.app/)
 | Windows | Windows 10 | x64 |
 | macOS | macOS 11 (Big Sur) | Intel/Apple Silicon |
 | Linux | Ubuntu 20.04+ / AppImage supported distros | x64 |
-
----
-<div align="center" markdown="1">
-  <a href="https://go.warp.dev/chatbox">
-    <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/refs/heads/main/Github/Sponsor/Warp-Github-LG-02.png">
-  </a>
-
-### [Warp, built for coding with multiple AI agents.](https://go.warp.dev/chatbox)
-[Available for MacOS, Linux, & Windows](https://go.warp.dev/chatbox)<br>
-</div>
-
-<hr>
-
-<h1 align="center">
-<img src='./doc/statics/icon.png' width='30'>
-<span>
-    Chatbox
-    <span style="font-size:8px; font-weight: normal;">(Community Edition)</span>
-</span>
-</h1>
-<p align="center">
-    <em>Your Ultimate AI Copilot on the Desktop. <br />Chatbox is a desktop client for ChatGPT, Claude and other LLMs, available on Windows, Mac, Linux</em>
-</p>
-
-<p align="center">
-<a href="https://github.com/chatboxai/chatbox/releases" target="_blank">
-<img alt="macOS" src="https://img.shields.io/badge/-macOS-black?style=flat-square&logo=apple&logoColor=white" />
-</a>
-<a href="https://github.com/chatboxai/chatbox/releases" target="_blank">
-<img alt="Windows" src="https://img.shields.io/badge/-Windows-blue?style=flat-square&logo=windows&logoColor=white" />
-</a>
-<a href="https://github.com/chatboxai/chatbox/releases" target="_blank">
-<img alt="Linux" src="https://img.shields.io/badge/-Linux-yellow?style=flat-square&logo=linux&logoColor=white" />
-</a>
-<a href="https://github.com/chatboxai/chatbox/releases" target="_blank">
-<img alt="Downloads" src="https://img.shields.io/github/downloads/chatboxai/chatbox/total.svg?style=flat" />
-</a>
-<a href="#features">
-<img alt="Privacy" src="https://img.shields.io/badge/-Local%20First-green?style=flat-square&logo=shield&logoColor=white" />
-</a>
-</p>
-
-<a href="https://www.producthunt.com/posts/chatbox?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-chatbox" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=429547&theme=light" alt="Chatbox - Better&#0032;UI&#0032;&#0038;&#0032;Desktop&#0032;App&#0032;for&#0032;ChatGPT&#0044;&#0032;Claude&#0032;and&#0032;other&#0032;LLMs&#0046; | Product Hunt" style="width: 150px; height: 30px;" width="100" height="40" /></a>
-
-<a href="./doc/statics/snapshot_light.png">
-<img src="./doc/statics/snapshot_light.png" width="400"/>
-</a>
-<a href="./doc/statics/snapshot_dark.png">
-<img src="./doc/statics/snapshot_dark.png" width="400"/>
-</a>
 
 <!-- <table>
 <tr>
@@ -222,12 +228,6 @@ For more information: [chatboxai.app](https://chatboxai.app/)
 ## FAQ
 
 -   [Frequently Asked Questions](./doc/FAQ.md)
-
-## Why I made Chatbox?
-
-I developed Chatbox initially because I was debugging some prompts and found myself in need of a simple and easy-to-use prompt and API debugging tool. I thought there might be more people who needed such a tool, so I open-sourced it.
-
-At first, I didn't know that it would be so popular. I listened to the feedback from the open-source community and continued to develop and improve it. Now, it has become a very useful AI desktop application. There are many users who love Chatbox, and they not only use it for developing and debugging prompts, but also for daily chatting, and even to do some more interesting things like using well-designed prompts to make AI play various professional roles to assist them in everyday work...
 
 ## How to Contribute
 
@@ -343,7 +343,7 @@ chatbox/
 
 ## Contact
 
-[Twitter](https://x.com/ChatboxAI_HQ) | [Email](mailto:hi@chatboxai.com)
+[Email](mailto:hi@chatboxai.com)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@
 </p>
 
 <div align="center" markdown="1">
+  <strong>Sponsored by Warp</strong>
+  <br>
+  <br>
   <a href="https://go.warp.dev/chatbox">
     <img alt="Warp sponsorship" width="400" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/refs/heads/main/Github/Sponsor/Warp-Github-LG-02.png">
   </a>


### PR DESCRIPTION
## Summary
- Move the project hero, badges, screenshots, and Warp sponsorship block to the top of the README
- Add the Trendshift badge alongside the existing Product Hunt badge
- Consolidate the download section and remove the "Why I made Chatbox?" section
- Remove the Twitter link from Contact

## Testing
- Not run; documentation-only change