### PR TITLE
Add input box font size setting

### DIFF
--- a/src/renderer/components/InputBox/InputBox.tsx
+++ b/src/renderer/components/InputBox/InputBox.tsx
@@ -164,6 +164,7 @@ const InputBox = forwardRef<InputBoxRef, InputBoxProps>(
     const { height: viewportHeight } = useViewportSize()
     const pasteLongTextAsAFile = useSettingsStore((state) => state.pasteLongTextAsAFile)
     const shortcuts = useSettingsStore((state) => state.shortcuts)
+    const inputBoxFontSize = useSettingsStore((state) => state.inputBoxFontSize)
     const widthFull = useUIStore((s) => s.widthFull) || fullWidth
     const saveBlob = useSaveBlob()
 
@@ -917,7 +918,7 @@ const InputBox = forwardRef<InputBoxRef, InputBoxProps>(
             <Flex align="flex-end" gap={4}>
               <Textarea
                 unstyled={true}
-                styles={{ input: { fontSize: 14 } }}
+                styles={{ input: { fontSize: inputBoxFontSize } }}
                 classNames={{
                   root: 'flex-1',
                   wrapper: 'flex-1',

--- a/src/renderer/i18n/locales/en/translation.json
+++ b/src/renderer/i18n/locales/en/translation.json
@@ -342,6 +342,8 @@
   "Focus on the Input Box and Enter Web Browsing Mode": "Focus on the Input Box and Enter Web Browsing Mode",
   "Follow System": "Follow System",
   "Font Size": "Font Size",
+  "Chat Font Size": "Chat Font Size",
+  "Input Box Font Size": "Input Box Font Size",
   "For general conversations, please click": "For general conversations, please click",
   "Format": "Format",
   "Free trial available": "Free trial available",

--- a/src/renderer/i18n/locales/zh-Hans/translation.json
+++ b/src/renderer/i18n/locales/zh-Hans/translation.json
@@ -342,6 +342,8 @@
   "Focus on the Input Box and Enter Web Browsing Mode": "聚焦到输入框并进入联网问答模式",
   "Follow System": "跟随系统",
   "Font Size": "字体大小",
+  "Chat Font Size": "聊天字体大小",
+  "Input Box Font Size": "输入框字体大小",
   "For general conversations, please click": "如需进行常规对话，请点击",
   "Format": "格式",
   "Free trial available": "免费试用Chatbox AI",

--- a/src/renderer/routes/settings/general.tsx
+++ b/src/renderer/routes/settings/general.tsx
@@ -98,7 +98,7 @@ export function RouteComponent() {
 
         {/* Font Size */}
         <Stack>
-          <Text>{t('Font Size')}</Text>
+          <Text>{t('Chat Font Size')}</Text>
           <LazySlider
             step={1}
             min={10}
@@ -113,6 +113,28 @@ export function RouteComponent() {
             onChange={(val) =>
               setSettings({
                 fontSize: val,
+              })
+            }
+          />
+        </Stack>
+
+        {/* Input Box Font Size */}
+        <Stack>
+          <Text>{t('Input Box Font Size')}</Text>
+          <LazySlider
+            step={1}
+            min={10}
+            max={22}
+            maw={320}
+            marks={[
+              {
+                value: 14,
+              },
+            ]}
+            value={settings.inputBoxFontSize}
+            onChange={(val) =>
+              setSettings({
+                inputBoxFontSize: val,
               })
             }
           />

--- a/src/renderer/stores/atoms/settingsAtoms.ts
+++ b/src/renderer/stores/atoms/settingsAtoms.ts
@@ -74,6 +74,7 @@ export const userAvatarKeyAtom = focusAtom(settingsAtom, (optic) => optic.prop('
 export const defaultAssistantAvatarKeyAtom = focusAtom(settingsAtom, (optic) => optic.prop('defaultAssistantAvatarKey'))
 export const themeAtom = focusAtom(settingsAtom, (optic) => optic.prop('theme'))
 export const fontSizeAtom = focusAtom(settingsAtom, (optic) => optic.prop('fontSize'))
+export const inputBoxFontSizeAtom = focusAtom(settingsAtom, (optic) => optic.prop('inputBoxFontSize'))
 export const spellCheckAtom = focusAtom(settingsAtom, (optic) => optic.prop('spellCheck'))
 export const allowReportingAndTrackingAtom = focusAtom(settingsAtom, (optic) => optic.prop('allowReportingAndTracking'))
 export const enableMarkdownRenderingAtom = focusAtom(settingsAtom, (optic) => optic.prop('enableMarkdownRendering'))

--- a/src/shared/defaults.ts
+++ b/src/shared/defaults.ts
@@ -81,6 +81,7 @@ export function settings(): Settings {
     theme: Theme.System,
     language: 'en',
     fontSize: 14,
+    inputBoxFontSize: 14,
     spellCheck: true,
 
     defaultPrompt: getDefaultPrompt(),

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -370,6 +370,7 @@ export const SettingsSchema = GlobalSessionSettingsSchema.extend({
   ]),
   languageInited: z.boolean().optional(),
   fontSize: z.number().catch(14),
+  inputBoxFontSize: z.number().catch(14),
   spellCheck: z.boolean().optional(),
 
   startupPage: z.enum(['home', 'session']).optional(),


### PR DESCRIPTION
### Description

Closes #3668

This PR adds a separate **Input Box Font Size** setting under General Settings.

Main changes:
- Adds `inputBoxFontSize` to the settings schema and defaults, with a default value of `14`.
- Adds a new slider in General Settings for configuring the input box font size.
- Renames the existing display font slider label to **Chat Font Size**, so it is clearer that it controls chat/message text.
- Applies the configured input box font size to the message input textarea instead of using the previous hardcoded `14px`.

### Additional Notes

Validation:
- Ran `pnpm exec biome check` on the changed files. It completed successfully, with only pre-existing warnings in touched files.
- Ran `pnpm exec tsc --noEmit --pretty false`; the repository currently has unrelated baseline TypeScript errors on `main`.

### Screenshots

N/A

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[x] I have read and agree with the above statement.