### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/src/shared/providers/definitions/minimax.ts
+++ b/src/shared/providers/definitions/minimax.ts
@@ -25,19 +25,13 @@ function createMiniMaxProvider(config: {
       apiHost: config.apiHost,
       models: [
         {
-          modelId: 'MiniMax-M2.5',
+          modelId: 'MiniMax-M3',
         },
         {
-          modelId: 'MiniMax-M2.5-highspeed',
+          modelId: 'MiniMax-M2.7',
         },
         {
-          modelId: 'MiniMax-M2.1',
-        },
-        {
-          modelId: 'MiniMax-M2.1-highspeed',
-        },
-        {
-          modelId: 'MiniMax-M2',
+          modelId: 'MiniMax-M2.7-highspeed',
         },
       ],
     },


### PR DESCRIPTION
## Summary

Upgrade MiniMax model configuration to include the latest M3 model as the new default, while keeping M2.7 as a fallback.

## Changes

- Add `MiniMax-M3` to the model selection list and set it as the new default (first entry)
- Add `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove deprecated older versions (`MiniMax-M2.5` / `MiniMax-M2.5-highspeed` / `MiniMax-M2.1` / `MiniMax-M2.1-highspeed` / `MiniMax-M2`) from the list

## Why

MiniMax-M3 is the new flagship model from MiniMax, with 512K context window, 128K max output, and image input support, available through both OpenAI-compatible and Anthropic-compatible interfaces. Keeping `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` ensures users with workflows still pinned to the previous generation can keep using them.

## Testing

- Manually verified the new model ID `MiniMax-M3` resolves through the existing OpenAI-compatible adapter against `https://api.minimax.io/v1`
- No tests reference the previous model IDs, so no test updates are needed