### PR TITLE
✨ feat: add ChinaLLM as model provider

### DIFF
--- a/src/shared/models/chinallm.ts
+++ b/src/shared/models/chinallm.ts
@@ -1,0 +1,9 @@
+import { OpenAICompatible } from './openai-compatible'
+
+export class ChinaLLM extends OpenAICompatible {
+  name = 'ChinaLLM'
+
+  constructor(apiKey: string, apiHost: string) {
+    super(apiKey, apiHost)
+  }
+}

--- a/src/shared/models/index.ts
+++ b/src/shared/models/index.ts
@@ -30,6 +30,7 @@ export const aiProviderNameHash: Record<ModelProviderEnum, string> = {
   [ModelProviderEnum.OpenRouter]: 'OpenRouter API',
   [ModelProviderEnum.Bedrock]: 'AWS Bedrock',
   [ModelProviderEnum.VercelAIGateway]: 'Vercel AI Gateway',
+  [ModelProviderEnum.ChinaLLM]: 'ChinaLLM API',
   [ModelProviderEnum.Custom]: 'Custom Provider',
 }
 
@@ -148,6 +149,11 @@ export const AIModelProviderMenuOptionList = [
   {
     value: ModelProviderEnum.VercelAIGateway,
     label: aiProviderNameHash[ModelProviderEnum.VercelAIGateway],
+    disabled: false,
+  },
+  {
+    value: ModelProviderEnum.ChinaLLM,
+    label: aiProviderNameHash[ModelProviderEnum.ChinaLLM],
     disabled: false,
   },
   {

--- a/src/shared/providers/definitions/chinallm.ts
+++ b/src/shared/providers/definitions/chinallm.ts
@@ -1,0 +1,59 @@
+import { ModelProviderEnum, ModelProviderType } from '../../types'
+import { defineProvider } from '../registry'
+import ChinaLLMModel from './models/chinallm'
+
+export const chinallmProvider = defineProvider({
+  id: ModelProviderEnum.ChinaLLM,
+  name: 'ChinaLLM',
+  type: ModelProviderType.OpenAI,
+  modelsDevProviderId: 'chinallm',
+  curatedModelIds: ['deepseek-chat', 'deepseek-reasoner', 'qwen-plus', 'qwen-max', 'glm-4-flash'],
+  urls: {
+    website: 'https://chinallm.dev',
+  },
+  defaultSettings: {
+    models: [
+      {
+        modelId: 'deepseek-chat',
+        contextWindow: 65536,
+        capabilities: ['tool_use'],
+      },
+      {
+        modelId: 'deepseek-reasoner',
+        contextWindow: 65536,
+        capabilities: ['reasoning', 'tool_use'],
+      },
+      {
+        modelId: 'qwen-plus',
+        contextWindow: 131072,
+        capabilities: ['vision'],
+      },
+      {
+        modelId: 'qwen-max',
+        contextWindow: 32768,
+        capabilities: ['vision', 'tool_use'],
+      },
+      {
+        modelId: 'glm-4-flash',
+        contextWindow: 128000,
+        capabilities: ['tool_use'],
+      },
+    ],
+  },
+  createModel: (config) => {
+    return new ChinaLLMModel(
+      {
+        apiKey: config.effectiveApiKey,
+        model: config.model,
+        temperature: config.settings.temperature,
+        topP: config.settings.topP,
+        maxOutputTokens: config.settings.maxTokens,
+        stream: config.settings.stream,
+      },
+      config.dependencies
+    )
+  },
+  getDisplayName: (modelId, providerSettings) => {
+    return `ChinaLLM (${providerSettings?.models?.find((m) => m.modelId === modelId)?.nickname || modelId})`
+  },
+})

--- a/src/shared/providers/definitions/models/chinallm.ts
+++ b/src/shared/providers/definitions/models/chinallm.ts
@@ -1,0 +1,64 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import type { LanguageModelV3 } from '@ai-sdk/provider'
+import AbstractAISDKModel, { type CallSettings } from '../../../models/abstract-ai-sdk'
+import type { CallChatCompletionOptions } from '../../../models/types'
+import type { ProviderModelInfo, ToolUseScope } from '../../../types'
+import type { ModelDependencies } from '../../../types/adapters'
+
+interface Options {
+  apiKey: string
+  model: ProviderModelInfo
+  temperature?: number
+  topP?: number
+  maxOutputTokens?: number
+  stream?: boolean
+}
+
+export default class ChinaLLM extends AbstractAISDKModel {
+  public name = 'ChinaLLM'
+
+  constructor(
+    public options: Options,
+    dependencies: ModelDependencies
+  ) {
+    super(options, dependencies)
+  }
+
+  protected getProvider() {
+    return createOpenAI({
+      apiKey: this.options.apiKey,
+      baseURL: 'https://api.chinallm.dev/v1',
+      compatibility: 'strict',
+    })
+  }
+
+  protected getChatModel(_options: CallChatCompletionOptions): LanguageModelV3 {
+    const provider = this.getProvider()
+    return provider.chat(this.options.model.modelId)
+  }
+
+  protected getCallSettings(_options: CallChatCompletionOptions): CallSettings {
+    const isReasonerModel = this.options.model.modelId === 'deepseek-reasoner'
+    const settings: CallSettings = {
+      maxOutputTokens: this.options.maxOutputTokens,
+    }
+
+    if (!isReasonerModel) {
+      settings.temperature = this.options.temperature
+      settings.topP = this.options.topP
+    }
+
+    return settings
+  }
+
+  isSupportToolUse(scope?: ToolUseScope) {
+    if (
+      scope &&
+      ['web-browsing', 'read-file'].includes(scope) &&
+      /deepseek-(v3|r1)$/.test(this.options.model.modelId.toLowerCase())
+    ) {
+      return false
+    }
+    return super.isSupportToolUse()
+  }
+}

--- a/src/shared/providers/index.ts
+++ b/src/shared/providers/index.ts
@@ -29,6 +29,7 @@ import './definitions/chatglm'
 import './definitions/github-copilot'
 import './definitions/bedrock'
 import './definitions/vercel-ai-gateway'
+import './definitions/chinallm'
 import {
   clearProviderRegistry,
   defineProvider,

--- a/src/shared/types/provider.ts
+++ b/src/shared/types/provider.ts
@@ -27,6 +27,7 @@ export enum ModelProviderEnum {
   OpenRouter = 'openrouter',
   Bedrock = 'bedrock',
   VercelAIGateway = 'vercel-ai-gateway',
+  ChinaLLM = 'chinallm',
   Custom = 'custom',
 }
 


### PR DESCRIPTION
Adds ChinaLLM (chinallm.dev) as a built-in model provider.

ChinaLLM provides OpenAI-compatible API access to Chinese LLMs (DeepSeek, Qwen, GLM, etc.) at lower costs.

Changes:
- Added `ChinaLLM` to `ModelProviderEnum`
- Created provider definition with default models (deepseek-chat, deepseek-reasoner, qwen-plus, qwen-max, glm-4-flash)
- Created model class extending `AbstractAISDKModel` using `@ai-sdk/openai`
- Registered in provider name hash, menu option list, and definitions index