### PR TITLE
fix: preserve OpenAI OAuth prompt cache affinity

### DIFF
--- a/src/shared/providers/definitions/models/openai-responses.test.ts
+++ b/src/shared/providers/definitions/models/openai-responses.test.ts
@@ -55,10 +55,11 @@ function createModel(overrides: Partial<ConstructorParameters<typeof OpenAIRespo
 }
 
 describe('OpenAIResponses call settings', () => {
-  it('forces store=false for stateless responses while preserving user OpenAI provider options', () => {
+  it('forces store=false and uses the stable session ID as the prompt cache key', () => {
     const openaiResponses = createModel()
 
     const settings = openaiResponses.exposeCallSettings({
+      sessionId: 'session-123',
       providerOptions: {
         openai: {
           reasoningEffort: 'high',
@@ -69,6 +70,19 @@ describe('OpenAIResponses call settings', () => {
     expect(settings.providerOptions).toEqual({
       openai: {
         reasoningEffort: 'high',
+        promptCacheKey: 'session-123',
+        store: false,
+      },
+    })
+  })
+
+  it('does not inject an empty prompt cache key when a stateless request has no session ID', () => {
+    const openaiResponses = createModel()
+
+    const settings = openaiResponses.exposeCallSettings()
+
+    expect(settings.providerOptions).toEqual({
+      openai: {
         store: false,
       },
     })

--- a/src/shared/providers/definitions/models/openai-responses.ts
+++ b/src/shared/providers/definitions/models/openai-responses.ts
@@ -44,6 +44,7 @@ export default class OpenAIResponses extends AbstractAISDKModel {
       this.options.model.modelId,
       options.providerOptions?.openai
     )
+    const promptCacheKey = options.sessionId
 
     return {
       temperature: this.options.temperature,
@@ -57,6 +58,7 @@ export default class OpenAIResponses extends AbstractAISDKModel {
       providerOptions: {
         openai: {
           ...openaiProviderOptions,
+          ...(promptCacheKey ? { promptCacheKey } : {}),
           store: false,
         },
       },


### PR DESCRIPTION
### Description

OpenAI OAuth requests use stateless Responses API calls and already carry the Chatbox session ID through the chat orchestration layer. However, the session ID was not propagated to OpenAI's `prompt_cache_key` option, so consecutive requests could lose prompt-cache affinity.

This change:

- Uses the existing session ID as `promptCacheKey` for stateless OAuth Responses requests.
- Preserves `store: false` for OAuth requests.
- Avoids changing behavior for regular API-key Responses providers.
- Adds regression tests for session and missing-session cases.

### Testing

- Targeted Vitest tests passed (4/4)
- Biome check passed
- TypeScript check passed
- Electron production build passed
- `git diff --check` passed

The full local suite also exposed unrelated environment-specific failures in Electron dependency installation and one Windows path-separator assertion; no failures were caused by the changed files.

### Additional Notes

This uses the official OpenAI Responses API `prompt_cache_key` provider option and does not modify OAuth endpoints, token handling, or authentication behavior.

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the contribution terms in the repository's PR template.

- [x] I have read and agree with the above statement.