### PR TITLE
Add configurable Anthropic prompt cache TTL settings

### DIFF
--- a/packages/chatbox-core/src/domain/settings/settings-schema.ts
+++ b/packages/chatbox-core/src/domain/settings/settings-schema.ts
@@ -120,8 +120,6 @@ const ProviderBaseInfoSchema = z.discriminatedUnion('isCustom', [
   CustomProviderBaseInfoSchema,
 ])
 
-const ClaudeCacheTTLSchema = z.enum(['auto', '5m', '1h'])
-
 const ClaudeParamsSchema = z.object({
   thinking: z
     .object({
@@ -131,7 +129,6 @@ const ClaudeParamsSchema = z.object({
     .optional()
     .catch(undefined),
   effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional().catch(undefined),
-  cacheTTL: ClaudeCacheTTLSchema.optional().catch('auto'),
 })
 
 const OpenAIParamsSchema = z.object({
@@ -198,6 +195,7 @@ export const GlobalSessionSettingsSchema = z.object({
 
 export const SessionSettingsSchema = GlobalSessionSettingsSchema.extend({
   provider: z.string().optional().catch(undefined),
+  cacheTTL: z.enum(['auto', '5m', '1h']).optional().catch('auto'),
   modelId: z.string().optional().catch(undefined),
   dalleStyle: z.enum(['vivid', 'natural']).optional().catch('vivid'),
   imageGenerateNum: z.number().optional().catch(1),

--- a/packages/chatbox-core/src/domain/settings/settings-schema.ts
+++ b/packages/chatbox-core/src/domain/settings/settings-schema.ts
@@ -120,6 +120,8 @@ const ProviderBaseInfoSchema = z.discriminatedUnion('isCustom', [
   CustomProviderBaseInfoSchema,
 ])
 
+const ClaudeCacheTTLSchema = z.enum(['auto', '5m', '1h'])
+
 const ClaudeParamsSchema = z.object({
   thinking: z
     .object({
@@ -129,6 +131,7 @@ const ClaudeParamsSchema = z.object({
     .optional()
     .catch(undefined),
   effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional().catch(undefined),
+  cacheTTL: ClaudeCacheTTLSchema.optional().catch('auto'),
 })
 
 const OpenAIParamsSchema = z.object({

--- a/src/renderer/modals/SessionSettings.tsx
+++ b/src/renderer/modals/SessionSettings.tsx
@@ -15,6 +15,7 @@ import { AssistantAvatar } from '@/components/common/Avatar'
 import LazyNumberInput from '@/components/common/LazyNumberInput'
 import MaxContextMessageCountSlider from '@/components/common/MaxContextMessageCountSlider'
 import { ScalableIcon } from '@/components/common/ScalableIcon'
+import SegmentedControl from '@/components/common/SegmentedControl'
 import SliderWithInput from '@/components/common/SliderWithInput'
 import { TooltipInfoTrigger } from '@/components/common/TooltipInfoTrigger'
 import { handleImageInputAndSave, ImageInStorage } from '@/components/Image'
@@ -512,6 +513,32 @@ export function ChatConfig({
           />
         </Flex>
       </Stack>
+      {settings?.provider === ModelProviderEnum.Claude && (
+        <Stack gap="xs">
+          <Text size="sm" fw="600">
+            {t('Prompt Cache')}
+          </Text>
+          <SegmentedControl
+            value={settings?.providerOptions?.claude?.cacheTTL ?? 'auto'}
+            onChange={(value) =>
+              onSettingsChange({
+                providerOptions: {
+                  ...settings?.providerOptions,
+                  claude: {
+                    ...settings?.providerOptions?.claude,
+                    cacheTTL: value as 'auto' | '5m' | '1h',
+                  },
+                },
+              })
+            }
+            data={[
+              { label: t('Auto'), value: 'auto' },
+              { label: t('5 min'), value: '5m' },
+              { label: t('1 hour'), value: '1h' },
+            ]}
+          />
+        </Stack>
+      )}
     </Stack>
   )
 }

--- a/src/renderer/modals/SessionSettings.tsx
+++ b/src/renderer/modals/SessionSettings.tsx
@@ -519,16 +519,10 @@ export function ChatConfig({
             {t('Prompt Cache')}
           </Text>
           <SegmentedControl
-            value={settings?.providerOptions?.claude?.cacheTTL ?? 'auto'}
+            value={settings?.cacheTTL ?? 'auto'}
             onChange={(value) =>
               onSettingsChange({
-                providerOptions: {
-                  ...settings?.providerOptions,
-                  claude: {
-                    ...settings?.providerOptions?.claude,
-                    cacheTTL: value as 'auto' | '5m' | '1h',
-                  },
-                },
+                cacheTTL: value as 'auto' | '5m' | '1h',
               })
             }
             data={[

--- a/src/shared/models/anthropic-cache.test.ts
+++ b/src/shared/models/anthropic-cache.test.ts
@@ -97,6 +97,22 @@ describe('addAnthropicCacheControl', () => {
     expect(anthropic.thinking).toEqual({ type: 'enabled', budgetTokens: 1000 })
   })
 
+  it('adds 5m TTL when explicitly requested', () => {
+    const messages: ModelMessage[] = [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }]
+    const result = addAnthropicCacheControl(messages, '5m')
+    const anthropic = result[0].providerOptions?.anthropic as Record<string, unknown>
+
+    expect(anthropic.cacheControl).toEqual({ type: 'ephemeral', ttl: '5m' })
+  })
+
+  it('adds 1h TTL when explicitly requested', () => {
+    const messages: ModelMessage[] = [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }]
+    const result = addAnthropicCacheControl(messages, '1h')
+    const anthropic = result[0].providerOptions?.anthropic as Record<string, unknown>
+
+    expect(anthropic.cacheControl).toEqual({ type: 'ephemeral', ttl: '1h' })
+  })
+
   it('handles no system message with only one user message', () => {
     const messages: ModelMessage[] = [{ role: 'user', content: [{ type: 'text', text: 'only one' }] }]
     const result = addAnthropicCacheControl(messages)

--- a/src/shared/models/anthropic-cache.ts
+++ b/src/shared/models/anthropic-cache.ts
@@ -10,7 +10,7 @@ import type { ModelMessage } from 'ai'
  * Works with both direct Anthropic API and AWS Bedrock.
  * See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
  */
-export function addAnthropicCacheControl(messages: ModelMessage[]): ModelMessage[] {
+export function addAnthropicCacheControl(messages: ModelMessage[], ttl: '5m' | '1h' = '5m'): ModelMessage[] {
   if (messages.length === 0) {
     return messages
   }

--- a/src/shared/models/anthropic-cache.ts
+++ b/src/shared/models/anthropic-cache.ts
@@ -10,7 +10,7 @@ import type { ModelMessage } from 'ai'
  * Works with both direct Anthropic API and AWS Bedrock.
  * See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
  */
-export function addAnthropicCacheControl(messages: ModelMessage[], ttl: '5m' | '1h' = '5m'): ModelMessage[] {
+export function addAnthropicCacheControl(messages: ModelMessage[], ttl?: '5m' | '1h'): ModelMessage[] {
   if (messages.length === 0) {
     return messages
   }
@@ -47,7 +47,10 @@ export function addAnthropicCacheControl(messages: ModelMessage[], ttl: '5m' | '
         ...msg.providerOptions,
         anthropic: {
           ...(msg.providerOptions?.anthropic as Record<string, unknown> | undefined),
-          cacheControl: { type: 'ephemeral', ttl },
+          cacheControl: {
+            type: 'ephemeral',
+            ...(ttl ? { ttl } : {}),
+          },
         },
       },
     }

--- a/src/shared/models/anthropic-cache.ts
+++ b/src/shared/models/anthropic-cache.ts
@@ -47,7 +47,7 @@ export function addAnthropicCacheControl(messages: ModelMessage[], ttl: '5m' | '
         ...msg.providerOptions,
         anthropic: {
           ...(msg.providerOptions?.anthropic as Record<string, unknown> | undefined),
-          cacheControl: { type: 'ephemeral' },
+          cacheControl: { type: 'ephemeral', ttl },
         },
       },
     }

--- a/src/shared/providers/definitions/claude.ts
+++ b/src/shared/providers/definitions/claude.ts
@@ -105,7 +105,7 @@ export const claudeProvider = defineProvider({
         topP: config.settings.topP,
         maxOutputTokens: config.settings.maxTokens,
         stream: config.settings.stream,
-        cacheTTL: config.settings.providerOptions?.claude?.cacheTTL,
+        cacheTTL: config.settings.cacheTTL,
         extraHeaders: oauthHeaders,
         customFetch:
           isOAuth && credentialManager ? createBearerOAuthFetch(config.dependencies, credentialManager) : undefined,

--- a/src/shared/providers/definitions/claude.ts
+++ b/src/shared/providers/definitions/claude.ts
@@ -105,6 +105,7 @@ export const claudeProvider = defineProvider({
         topP: config.settings.topP,
         maxOutputTokens: config.settings.maxTokens,
         stream: config.settings.stream,
+        cacheTTL: config.settings.providerOptions?.claude?.cacheTTL,
         extraHeaders: oauthHeaders,
         customFetch:
           isOAuth && credentialManager ? createBearerOAuthFetch(config.dependencies, credentialManager) : undefined,

--- a/src/shared/providers/definitions/models/claude.ts
+++ b/src/shared/providers/definitions/models/claude.ts
@@ -133,14 +133,7 @@ export default class Claude extends AbstractAISDKModel {
   }
 
   public async chat(messages: ModelMessage[], options: CallChatCompletionOptions): Promise<StreamTextResult> {
-    const ttl =
-      this.options.cacheTTL === '5m'
-        ? '5m'
-        : this.options.cacheTTL === '1h'
-          ? '1h'
-          : messages.length >= 10
-            ? '1h'
-            : '5m'
+    const ttl = this.options.cacheTTL === '5m' || this.options.cacheTTL === '1h' ? this.options.cacheTTL : undefined
     return super.chat(addAnthropicCacheControl(messages, ttl), options)
   }
 
@@ -148,14 +141,7 @@ export default class Claude extends AbstractAISDKModel {
     messages: ModelMessage[],
     options: ChatStreamOptions
   ): AsyncGenerator<ModelStreamPart<T>> {
-    const ttl =
-      this.options.cacheTTL === '5m'
-        ? '5m'
-        : this.options.cacheTTL === '1h'
-          ? '1h'
-          : messages.length >= 10
-            ? '1h'
-            : '5m'
+    const ttl = this.options.cacheTTL === '5m' || this.options.cacheTTL === '1h' ? this.options.cacheTTL : undefined
     yield* super.chatStream<T>(addAnthropicCacheControl(messages, ttl), options)
   }
 

--- a/src/shared/providers/definitions/models/claude.ts
+++ b/src/shared/providers/definitions/models/claude.ts
@@ -17,6 +17,7 @@ interface Options {
   topP?: number
   maxOutputTokens?: number
   stream?: boolean
+  cacheTTL?: 'auto' | '5m' | '1h'
   extraHeaders?: Record<string, string>
   customFetch?: typeof globalThis.fetch
   authToken?: string
@@ -132,14 +133,30 @@ export default class Claude extends AbstractAISDKModel {
   }
 
   public async chat(messages: ModelMessage[], options: CallChatCompletionOptions): Promise<StreamTextResult> {
-    return super.chat(addAnthropicCacheControl(messages), options)
+    const ttl =
+      this.options.cacheTTL === '5m'
+        ? '5m'
+        : this.options.cacheTTL === '1h'
+          ? '1h'
+          : messages.length >= 10
+            ? '1h'
+            : '5m'
+    return super.chat(addAnthropicCacheControl(messages, ttl), options)
   }
 
   public async *chatStream<T extends ToolSet>(
     messages: ModelMessage[],
     options: ChatStreamOptions
   ): AsyncGenerator<ModelStreamPart<T>> {
-    yield* super.chatStream<T>(addAnthropicCacheControl(messages), options)
+    const ttl =
+      this.options.cacheTTL === '5m'
+        ? '5m'
+        : this.options.cacheTTL === '1h'
+          ? '1h'
+          : messages.length >= 10
+            ? '1h'
+            : '5m'
+    yield* super.chatStream<T>(addAnthropicCacheControl(messages, ttl), options)
   }
 
   // https://docs.anthropic.com/en/docs/api/models


### PR DESCRIPTION
### Description

This PR adds configurable Anthropic prompt cache TTL settings.

Previously, Chatbox always used the default prompt cache TTL. This change allows users to choose the cache duration for Claude conversations from the session settings.

### Changes

- Add a new **Prompt Cache** setting for Claude sessions.
- Support three modes:
  - Auto
  - 5 minutes
  - 1 hour
- Pass the selected TTL to Anthropic using the `cache_control.ttl` field.
- Preserve the existing automatic behavior when **Auto** is selected.

### Additional Notes

The implementation was tested with the Anthropic API using both `5m` and `1h` TTL values.

No screenshots are included because the UI change is limited to a single additional session setting.

### Screenshots

N/A

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- [x] I have read and agree with the above statement.