### PR TITLE
fix: prevent MCP config secrets in logs

### DIFF
--- a/src/main/mcp/ipc-stdio-transport.test.ts
+++ b/src/main/mcp/ipc-stdio-transport.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+type IpcHandler = (
+  event: { sender: { send: ReturnType<typeof vi.fn> } },
+  serverParams: { command: string; args?: string[]; env?: Record<string, string> }
+) => Promise<string>
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<string, IpcHandler>()
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
+
+  class MockStdioClientTransport {
+    stderr = {
+      addListener: vi.fn(),
+      removeAllListeners: vi.fn(),
+    }
+    onclose?: () => void
+    onerror?: (error: Error) => void
+    onmessage?: (message: unknown) => void
+
+    async close() {}
+    async send() {}
+    async start() {}
+  }
+
+  return { handlers, logger, MockStdioClientTransport }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: IpcHandler) => {
+      mocks.handlers.set(channel, handler)
+    }),
+  },
+}))
+
+vi.mock('../util', () => ({
+  getLogger: () => mocks.logger,
+}))
+
+vi.mock('./shell-env', () => ({
+  shellEnv: vi.fn(async () => ({})),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: mocks.MockStdioClientTransport,
+}))
+
+const { closeAllTransports } = await import('./ipc-stdio-transport')
+
+describe('stdio transport IPC', () => {
+  afterEach(() => {
+    closeAllTransports()
+    mocks.logger.info.mockClear()
+  })
+
+  it('does not log stdio transport configuration', async () => {
+    const secret = 'do-not-log-this-token'
+    const createTransport = mocks.handlers.get('mcp:stdio-transport:create')
+    expect(createTransport).toBeDefined()
+
+    await createTransport?.(
+      { sender: { send: vi.fn() } },
+      {
+        command: 'node',
+        args: ['--api-key', secret],
+        env: { MCP_TOKEN: secret },
+      }
+    )
+
+    expect(mocks.logger.info).toHaveBeenCalledWith('create stdio transport')
+    expect(JSON.stringify(mocks.logger.info.mock.calls)).not.toContain(secret)
+  })
+})

--- a/src/main/mcp/ipc-stdio-transport.ts
+++ b/src/main/mcp/ipc-stdio-transport.ts
@@ -34,7 +34,7 @@ function getTransport(transportId: string) {
 }
 
 ipcMain.handle('mcp:stdio-transport:create', async (event, serverParams: StdioServerParameters) => {
-  logger.info('create', serverParams)
+  logger.info('create stdio transport')
 
   const postMessage = (channel: string, ...args: any[]) => {
     try {


### PR DESCRIPTION
## Summary

- avoid serializing stdio MCP command arguments and environment variables into the main log
- cover transport creation with argument and environment sentinels

## Tests

- pnpm exec vitest run src/main/mcp/ipc-stdio-transport.test.ts
