### PR TITLE
fix(iOS): route LM Studio through native HTTP

### DIFF
--- a/src/shared/providers/definitions/lmstudio.test.ts
+++ b/src/shared/providers/definitions/lmstudio.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import type { ModelDependencies } from '../../types/adapters'
+import type { CreateModelConfig } from '../types'
+import { lmStudioProvider } from './lmstudio'
+
+type LMStudioModel = {
+  options: {
+    useProxy?: boolean
+  }
+}
+
+function createModel(platformType: ModelDependencies['platformType'], useProxy?: boolean): LMStudioModel {
+  return lmStudioProvider.createModel({
+    settings: { provider: 'lm-studio', modelId: 'local-model' },
+    dependencies: { platformType } as ModelDependencies,
+    providerSetting: { useProxy },
+    formattedApiHost: 'http://192.168.1.10:1234',
+    model: { modelId: 'local-model' },
+  } as CreateModelConfig) as unknown as LMStudioModel
+}
+
+describe('LM Studio provider', () => {
+  it('uses the native request transport on mobile', () => {
+    expect(createModel('mobile').options.useProxy).toBe(true)
+  })
+
+  it('preserves the compatibility setting on desktop', () => {
+    expect(createModel('desktop', true).options.useProxy).toBe(true)
+    expect(createModel('desktop').options.useProxy).toBeUndefined()
+  })
+})

--- a/src/shared/providers/definitions/lmstudio.ts
+++ b/src/shared/providers/definitions/lmstudio.ts
@@ -18,6 +18,9 @@ export const lmStudioProvider = defineProvider({
         topP: config.settings.topP,
         maxOutputTokens: config.settings.maxTokens,
         stream: config.settings.stream,
+        // On mobile, this selects the native HTTP transport. It is required for
+        // direct LAN access (and lets iOS present its local-network prompt).
+        useProxy: config.dependencies.platformType === 'mobile' || config.providerSetting.useProxy,
       },
       config.dependencies
     )

--- a/src/shared/providers/definitions/models/lmstudio.ts
+++ b/src/shared/providers/definitions/models/lmstudio.ts
@@ -19,6 +19,7 @@ export default class LMStudio extends OpenAICompatible {
         topP: options.topP,
         maxOutputTokens: options.maxOutputTokens,
         stream: options.stream,
+        useProxy: options.useProxy,
       },
       dependencies
     )


### PR DESCRIPTION
## Summary
- Route LM Studio API requests through Capacitor's native HTTP transport on mobile.
- Preserve the existing compatibility setting for desktop.
- Cover mobile and desktop transport selection with a provider test.

This enables the actual LAN request that allows iOS to present its local-network permission prompt.

## Testing
- Not run: dependencies are not installed and `pnpm` is unavailable in this environment.