### PR TITLE
fix: support mobile LAN custom endpoints

### DIFF
--- a/src/renderer/packages/model-setting-utils/custom-provider-setting-util.test.ts
+++ b/src/renderer/packages/model-setting-utils/custom-provider-setting-util.test.ts
@@ -1,0 +1,86 @@
+import { ModelProviderEnum, ModelProviderType, type ProviderSettings } from '@shared/types'
+import type { ApiRequestOptions, ModelDependencies } from '@shared/types/adapters'
+import type { SentryScope } from '@shared/utils/sentry_adapter'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createModelDependencies } from '@/adapters'
+import CustomProviderSettingUtil from './custom-provider-setting-util'
+
+vi.mock('@/adapters', () => ({
+  createModelDependencies: vi.fn(),
+}))
+
+const mockScope: SentryScope = {
+  setTag: vi.fn(),
+  setExtra: vi.fn(),
+}
+
+class TestCustomProviderSettingUtil extends CustomProviderSettingUtil {
+  public listModels(settings: ProviderSettings) {
+    return this.listProviderModels(settings)
+  }
+}
+
+function createDependencies(apiRequest: ModelDependencies['request']['apiRequest']): ModelDependencies {
+  return {
+    request: {
+      apiRequest,
+      fetchWithOptions: vi.fn(),
+    },
+    storage: {
+      saveImage: vi.fn(),
+      getImage: vi.fn(),
+    },
+    sentry: {
+      captureException: vi.fn(),
+      withScope: vi.fn((callback: (scope: SentryScope) => void) => callback(mockScope)),
+    },
+    getRemoteConfig: vi.fn(),
+    platformType: 'mobile',
+  }
+}
+
+describe('CustomProviderSettingUtil network compatibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    {
+      type: ModelProviderType.Claude,
+      response: { data: [{ id: 'claude-test', type: 'model' }] },
+    },
+    {
+      type: ModelProviderType.Gemini,
+      response: {
+        models: [
+          {
+            name: 'models/gemini-test',
+            version: '1',
+            displayName: 'Gemini Test',
+            description: '',
+            inputTokenLimit: 1024,
+            outputTokenLimit: 128,
+            supportedGenerationMethods: ['generateContent'],
+            temperature: 1,
+            topP: 1,
+            topK: 1,
+          },
+        ],
+      },
+    },
+  ])('passes useProxy while listing $type models', async ({ type, response }) => {
+    const apiRequest = vi.fn((_options: ApiRequestOptions) =>
+      Promise.resolve(new Response(JSON.stringify(response), { headers: { 'content-type': 'application/json' } }))
+    )
+    vi.mocked(createModelDependencies).mockResolvedValue(createDependencies(apiRequest))
+    const util = new TestCustomProviderSettingUtil(ModelProviderEnum.Custom, type)
+
+    await util.listModels({
+      apiHost: 'http://192.168.1.10:8000',
+      apiKey: 'test-key',
+      useProxy: true,
+    })
+
+    expect(apiRequest).toHaveBeenCalledWith(expect.objectContaining({ useProxy: true }))
+  })
+})

--- a/src/renderer/packages/model-setting-utils/custom-provider-setting-util.ts
+++ b/src/renderer/packages/model-setting-utils/custom-provider-setting-util.ts
@@ -78,6 +78,7 @@ export default class CustomProviderSettingUtil extends BaseConfig implements Mod
             apiKey: settings.apiKey!,
             model,
             temperature: 0,
+            useProxy: settings.useProxy,
           },
           dependencies
         )
@@ -90,6 +91,7 @@ export default class CustomProviderSettingUtil extends BaseConfig implements Mod
             apiKey: settings.apiKey!,
             model,
             temperature: 0,
+            useProxy: settings.useProxy,
           },
           dependencies
         )

--- a/src/renderer/routes/settings/provider/$providerId.tsx
+++ b/src/renderer/routes/settings/provider/$providerId.tsx
@@ -716,6 +716,10 @@ function ProviderSettings({ providerId }: { providerId: string }) {
                 flex={1}
                 value={providerSettings?.apiHost || baseInfo.defaultSettings?.apiHost || ''}
                 onChange={handleApiHostChange}
+                inputMode="url"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
               />
             </Flex>
             <Text span size="xs" flex="0 1 auto" c="chatbox-secondary">
@@ -741,6 +745,10 @@ function ProviderSettings({ providerId }: { providerId: string }) {
                       value={providerSettings?.apiHost}
                       placeholder={baseInfo.defaultSettings?.apiHost}
                       onChange={handleApiHostChange}
+                      inputMode="url"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      spellCheck={false}
                     />
                   </Flex>
                 </Stack>

--- a/src/shared/providers/definitions/models/custom-claude.ts
+++ b/src/shared/providers/definitions/models/custom-claude.ts
@@ -5,6 +5,7 @@ import AbstractAISDKModel, { type CallSettings } from '../../../models/abstract-
 import { addAnthropicCacheControl } from '../../../models/anthropic-cache'
 import { ApiError } from '../../../models/errors'
 import type { CallChatCompletionOptions, ChatStreamOptions, ModelStreamPart } from '../../../models/types'
+import { createFetchWithProxy } from '../../../models/utils/fetch-proxy'
 import type { ProviderModelInfo, StreamTextResult } from '../../../types'
 import type { ModelDependencies } from '../../../types/adapters'
 import { normalizeClaudeHost } from '../../../utils/llm_utils'
@@ -18,6 +19,7 @@ interface Options {
   topP?: number
   maxOutputTokens?: number
   stream?: boolean
+  useProxy?: boolean
 }
 
 export default class CustomClaude extends AbstractAISDKModel {
@@ -37,6 +39,7 @@ export default class CustomClaude extends AbstractAISDKModel {
     return createAnthropic({
       baseURL: this.options.apiHost,
       apiKey: this.options.apiKey,
+      fetch: createFetchWithProxy(this.options.useProxy, this.dependencies),
       headers: {
         'anthropic-dangerous-direct-browser-access': 'true',
       },
@@ -92,6 +95,7 @@ export default class CustomClaude extends AbstractAISDKModel {
     const res = await this.dependencies.request.apiRequest({
       url: url,
       method: 'GET',
+      useProxy: this.options.useProxy,
       headers: {
         'anthropic-version': '2023-06-01',
         'anthropic-dangerous-direct-browser-access': 'true',

--- a/src/shared/providers/definitions/models/custom-gemini.ts
+++ b/src/shared/providers/definitions/models/custom-gemini.ts
@@ -4,6 +4,7 @@ import { generateText } from 'ai'
 import AbstractAISDKModel, { type CallSettings } from '../../../models/abstract-ai-sdk'
 import { ApiError } from '../../../models/errors'
 import type { CallChatCompletionOptions } from '../../../models/types'
+import { createFetchWithProxy } from '../../../models/utils/fetch-proxy'
 import type { ProviderModelInfo } from '../../../types'
 import type { ModelDependencies } from '../../../types/adapters'
 import { normalizeGoogleThinkingConfig } from '../../../utils/google-thinking'
@@ -19,6 +20,7 @@ interface Options {
   topP?: number
   maxOutputTokens?: number
   stream?: boolean
+  useProxy?: boolean
 }
 
 export default class CustomGemini extends AbstractAISDKModel {
@@ -45,6 +47,7 @@ export default class CustomGemini extends AbstractAISDKModel {
     return createGoogleGenerativeAI({
       apiKey: this.options.apiKey,
       baseURL: normalizeGeminiHost(this.options.apiHost).apiHost,
+      fetch: createFetchWithProxy(this.options.useProxy, this.dependencies),
     })
   }
 
@@ -168,6 +171,7 @@ export default class CustomGemini extends AbstractAISDKModel {
       const res = await this.dependencies.request.apiRequest({
         url: `${apiHost}/models?key=${this.options.apiKey}`,
         method: 'GET',
+        useProxy: this.options.useProxy,
         headers: {},
       })
       const json: Response = await res.json()

--- a/src/shared/providers/definitions/models/custom-provider-proxy.test.ts
+++ b/src/shared/providers/definitions/models/custom-provider-proxy.test.ts
@@ -1,0 +1,195 @@
+import type { ApiRequestOptions, ModelDependencies } from '@shared/types/adapters'
+import type { SentryScope } from '@shared/utils/sentry_adapter'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ModelProviderType } from '../../../types'
+import type { CreateModelConfig } from '../../types'
+import { createCustomProviderModel } from '../../utils'
+import CustomClaude from './custom-claude'
+import CustomGemini from './custom-gemini'
+
+const mockScope: SentryScope = {
+  setTag: vi.fn(),
+  setExtra: vi.fn(),
+}
+
+function createDependencies(apiRequest: ModelDependencies['request']['apiRequest']): ModelDependencies {
+  return {
+    request: {
+      apiRequest,
+      fetchWithOptions: vi.fn(),
+    },
+    storage: {
+      saveImage: vi.fn(),
+      getImage: vi.fn(),
+    },
+    sentry: {
+      captureException: vi.fn(),
+      withScope: vi.fn((callback: (scope: SentryScope) => void) => callback(mockScope)),
+    },
+    getRemoteConfig: vi.fn(),
+    platformType: 'mobile',
+  }
+}
+
+describe('custom provider network compatibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards useProxy when creating Custom Claude and Gemini models', () => {
+    const dependencies = createDependencies(vi.fn())
+    const config = {
+      settings: {} as CreateModelConfig['settings'],
+      globalSettings: {} as CreateModelConfig['globalSettings'],
+      config: {} as CreateModelConfig['config'],
+      dependencies,
+      providerSetting: { useProxy: true },
+      formattedApiHost: 'http://192.168.1.10:8000',
+      formattedApiPath: '',
+      model: { modelId: 'test-model', type: 'chat' as const },
+      effectiveApiKey: 'test-key',
+    } satisfies CreateModelConfig
+
+    const claude = createCustomProviderModel(config, ModelProviderType.Claude, dependencies) as CustomClaude
+    const gemini = createCustomProviderModel(config, ModelProviderType.Gemini, dependencies) as CustomGemini
+
+    expect(claude.options.useProxy).toBe(true)
+    expect(gemini.options.useProxy).toBe(true)
+  })
+
+  it('routes Custom Claude chat and model listing through useProxy', async () => {
+    const apiRequest = vi.fn((options: ApiRequestOptions) => {
+      if (options.method === 'POST') {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: 'msg_test',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-test',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              stop_sequence: null,
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+            { headers: { 'content-type': 'application/json' } }
+          )
+        )
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: [{ id: 'claude-test', type: 'model' }],
+          }),
+          { headers: { 'content-type': 'application/json' } }
+        )
+      )
+    })
+    const dependencies = createDependencies(apiRequest)
+    const model = new CustomClaude(
+      {
+        apiKey: 'test-key',
+        apiHost: 'http://192.168.1.10:8000/v1',
+        model: { modelId: 'claude-test', type: 'chat' },
+        useProxy: true,
+      },
+      dependencies
+    )
+
+    await model.chat([{ role: 'user', content: 'hello' }], {})
+    await model.listModels()
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        url: 'http://192.168.1.10:8000/v1/messages',
+        useProxy: true,
+        retry: 0,
+      })
+    )
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'GET',
+        url: 'http://192.168.1.10:8000/v1/models?limit=990',
+        useProxy: true,
+      })
+    )
+  })
+
+  it('routes Custom Gemini chat and model listing through useProxy', async () => {
+    const apiRequest = vi.fn((options: ApiRequestOptions) => {
+      if (options.method === 'POST') {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              candidates: [
+                {
+                  content: { role: 'model', parts: [{ text: 'ok' }] },
+                  finishReason: 'STOP',
+                },
+              ],
+              usageMetadata: {
+                promptTokenCount: 1,
+                candidatesTokenCount: 1,
+                totalTokenCount: 2,
+              },
+            }),
+            { headers: { 'content-type': 'application/json' } }
+          )
+        )
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            models: [
+              {
+                name: 'models/gemini-test',
+                version: '1',
+                displayName: 'Gemini Test',
+                description: '',
+                inputTokenLimit: 1024,
+                outputTokenLimit: 128,
+                supportedGenerationMethods: ['generateContent'],
+                temperature: 1,
+                topP: 1,
+                topK: 1,
+              },
+            ],
+          }),
+          { headers: { 'content-type': 'application/json' } }
+        )
+      )
+    })
+    const dependencies = createDependencies(apiRequest)
+    const model = new CustomGemini(
+      {
+        apiKey: 'test-key',
+        apiHost: 'http://192.168.1.10:8000',
+        model: { modelId: 'gemini-test', type: 'chat' },
+        useProxy: true,
+      },
+      dependencies
+    )
+
+    await model.chat([{ role: 'user', content: 'hello' }], {})
+    await model.listModels()
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        url: expect.stringContaining('http://192.168.1.10:8000/v1beta/models/gemini-test:'),
+        useProxy: true,
+        retry: 0,
+      })
+    )
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'GET',
+        url: 'http://192.168.1.10:8000/v1beta/models?key=test-key',
+        useProxy: true,
+      })
+    )
+  })
+})

--- a/src/shared/providers/utils.ts
+++ b/src/shared/providers/utils.ts
@@ -25,6 +25,7 @@ export function createCustomProviderModel(
           topP: settings.topP,
           maxOutputTokens: settings.maxTokens,
           stream: settings.stream,
+          useProxy: providerSetting.useProxy,
         },
         dependencies
       )
@@ -38,6 +39,7 @@ export function createCustomProviderModel(
           topP: settings.topP,
           maxOutputTokens: settings.maxTokens,
           stream: settings.stream,
+          useProxy: providerSetting.useProxy,
         },
         dependencies
       )

--- a/src/shared/utils/llm_utils.test.ts
+++ b/src/shared/utils/llm_utils.test.ts
@@ -34,6 +34,11 @@ describe('normalizeOpenAIApiHostAndPath', () => {
     expect(result.apiHost).toBe('http://localhost:8080/v1')
   })
 
+  it('normalizes mixed-case HTTP protocols from mobile keyboards', () => {
+    const result = normalizeOpenAIApiHostAndPath({ apiHost: 'Http://192.168.1.10:11434' })
+    expect(result.apiHost).toBe('http://192.168.1.10:11434/v1')
+  })
+
   it('extracts path when user puts full URL in apiHost', () => {
     const result = normalizeOpenAIApiHostAndPath({
       apiHost: 'https://my-proxy.com/v1/chat/completions',

--- a/src/shared/utils/llm_utils.ts
+++ b/src/shared/utils/llm_utils.ts
@@ -26,9 +26,13 @@ export function normalizeOpenAIApiHostAndPath(
   if (apiPath && !apiPath.startsWith('/')) {
     apiPath = '/' + apiPath
   }
-  // https 协议
-  if (apiHost && !apiHost.startsWith('http://') && !apiHost.startsWith('https://')) {
-    apiHost = 'https://' + apiHost
+  // URL schemes are case-insensitive. Mobile keyboards may capitalize the first
+  // character, so normalize an explicit HTTP(S) scheme before applying defaults.
+  const scheme = apiHost.match(/^https?:\/\//i)?.[0]
+  if (scheme) {
+    apiHost = `${scheme.toLowerCase()}${apiHost.slice(scheme.length)}`
+  } else {
+    apiHost = `https://${apiHost}`
   }
   // 如果用户在 host 配置了完整的 host+path 接口地址
   // 可以兼容的输入情况有：


### PR DESCRIPTION
## 问题

- [Issue 2414](https://github.com/chatboxai/chatbox/issues/2414)：移动端键盘可能把 `http://` 首字母自动大写为 `Http://`，地址预览随后被错误拼成 `https://Http://...`，导致局域网 Ollama 端点不可用。
- [Issue 3739](https://github.com/chatboxai/chatbox/issues/3739)：自定义 Claude/Gemini 虽然显示“Improve Network Compatibility”开关，但聊天请求和模型列表请求没有消费 `useProxy`，移动端仍走受 CORS 限制的 WebView fetch。

## 根因

- API Host 归一化只用大小写敏感的 `startsWith` 判断协议，URL 输入框也没有关闭移动端自动大写。
- `useProxy` 只在自定义 OpenAI/OpenAI Responses 链路中传递；Custom Claude/Gemini 的运行时模型创建、AI SDK fetch 和模型列表拉取均有断点。

## 修复

- 按大小写不敏感方式识别 HTTP(S) 协议，并将显式协议规范化为小写。
- API Host 输入使用 URL 键盘，并关闭自动大写、自动纠正与拼写检查。
- 将 `useProxy` 贯通 Custom Claude/Gemini 的运行时创建、AI SDK 自定义 fetch、模型列表请求以及设置页模型拉取。
- 增加混合大小写 HTTP 地址及 Claude/Gemini 聊天、模型列表、设置页传参的回归测试。

## 验证

- `pnpm exec vitest run src/shared/providers src/shared/utils/llm_utils.test.ts src/renderer/packages/model-setting-utils/custom-provider-setting-util.test.ts`（89 passed，6 skipped）
- `pnpm check`
- `pnpm format`
- `git diff --check`