### PR TITLE
feat(ui): refine minimal sidebar layout

### DIFF
--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -1,16 +1,13 @@
 import { registerPlugin } from '@capacitor/core'
-import NiceModal from '@ebay/nice-modal-react'
-import { ActionIcon, Box, Button, Flex, Image, NavLink, Stack, Text } from '@mantine/core'
+import { ActionIcon, Box, Button, Flex, Stack, Text } from '@mantine/core'
 import SwipeableDrawer from '@mui/material/SwipeableDrawer'
 import { TestId } from '@shared/automation/testids'
 import {
-  IconArchive,
   IconCirclePlus,
   IconCode,
   IconDownload,
   IconHelpCircle,
   IconInfoCircle,
-  IconLayoutSidebarLeftCollapse,
   IconMessageChatbot,
   IconPhotoPlus,
   IconSearch,
@@ -23,16 +20,14 @@ import { useTranslation } from 'react-i18next'
 import { AppTooltip as Tooltip } from '@/components/ui/tooltip'
 import Divider from './components/common/Divider'
 import { ScalableIcon } from './components/common/ScalableIcon'
-import ThemeSwitchButton from './components/dev/ThemeSwitchButton'
 import SessionList from './components/session/SessionList'
 import { FORCE_ENABLE_DEV_PAGES } from './dev/devToolsConfig'
-import useNeedRoomForMacWinControls from './hooks/useNeedRoomForWinControls'
+import useNeedRoomForWinControls from './hooks/useNeedRoomForWinControls'
 import { useIsSmallScreen, useSidebarWidth } from './hooks/useScreenChange'
 import useVersion from './hooks/useVersion'
 import { navigateToSettings } from './modals/Settings'
 import { trackingEvent } from './packages/event'
 import { getSidebarModalSx } from './sidebar-drawer'
-import icon from './static/icon.png'
 import { useLanguage } from './stores/settingsStore'
 import { useUIStore } from './stores/uiStore'
 import { installUpdate, useUpdateStore } from './stores/updateStore'
@@ -69,12 +64,11 @@ export default function Sidebar() {
   const sidebarWidth = useSidebarWidth()
 
   const isSmallScreen = useIsSmallScreen()
+  const { needRoomForMacWindowControls } = useNeedRoomForWinControls()
 
   const [isResizing, setIsResizing] = useState(false)
   const resizeStartX = useRef<number>(0)
   const resizeStartWidth = useRef<number>(0)
-
-  const { needRoomForMacWindowControls } = useNeedRoomForMacWinControls()
 
   const handleCreateNewSession = useCallback(() => {
     navigate({ to: `/` })
@@ -170,7 +164,7 @@ export default function Sidebar() {
         gap={0}
         pt="var(--mobile-safe-area-inset-top, 0px)"
         pb="var(--mobile-safe-area-inset-bottom, 0px)"
-        className="relative"
+        className="relative chatbox-sidebar"
       >
         {needRoomForMacWindowControls && <Box className="title-bar flex-[0_0_44px]" />}
         <Flex align="center" justify="space-between" gap="xs" px="md" py="sm" className="border-0">
@@ -181,7 +175,6 @@ export default function Sidebar() {
               onClick={() => navigate({ to: '/about' })}
               style={{ cursor: 'pointer', minWidth: 0 }}
             >
-              <Image src={icon} w={20} h={20} />
               <Text span c="chatbox-secondary" size="xl" lh={1.2} fw="700" truncate>
                 Chatbox
               </Text>
@@ -192,7 +185,6 @@ export default function Sidebar() {
                 </Text>
               )}
             </Flex>
-            {FORCE_ENABLE_DEV_PAGES && <ThemeSwitchButton size="xs" />}
           </Flex>
 
           <Flex align="center" gap={2} style={{ flexShrink: 0 }}>
@@ -207,158 +199,75 @@ export default function Sidebar() {
                 <IconSearch size={18} />
               </ActionIcon>
             </Tooltip>
-            <Tooltip label={t('Clear Conversation List')} openDelay={1000} withArrow>
-              <ActionIcon
-                variant="subtle"
-                color="chatbox-tertiary"
-                size={26}
-                radius="md"
-                onClick={() => NiceModal.show('clear-session-list')}
-              >
-                <IconArchive size={18} />
-              </ActionIcon>
-            </Tooltip>
-            <Tooltip label={t('Collapse')} openDelay={1000} withArrow>
-              <ActionIcon
-                variant="subtle"
-                color="chatbox-tertiary"
-                size={26}
-                radius="md"
-                onClick={() => setShowSidebar(false)}
-              >
-                <IconLayoutSidebarLeftCollapse size={18} />
-              </ActionIcon>
-            </Tooltip>
           </Flex>
         </Flex>
+
+        <Stack gap={6} px="sm" pb="sm" className="chatbox-sidebar-primary-actions">
+          <Button
+            variant="subtle"
+            fullWidth
+            radius="md"
+            justify="flex-start"
+            className="chatbox-sidebar-primary-action"
+            data-testid={TestId.sidebar.newChat}
+            onClick={handleCreateNewSession}
+          >
+            <ScalableIcon icon={IconCirclePlus} className="mr-2" />
+            {t('New Chat')}
+          </Button>
+          <Button
+            variant="subtle"
+            fullWidth
+            radius="md"
+            justify="flex-start"
+            className="chatbox-sidebar-primary-action"
+            data-testid={TestId.sidebar.newImage}
+            onClick={handleCreateNewPictureSession}
+          >
+            <ScalableIcon icon={IconPhotoPlus} className="mr-2" />
+            {t('Create Image')}
+          </Button>
+        </Stack>
 
         <SessionList sessionListViewportRef={sessionListViewportRef} />
 
         <SidebarUpdateBanner />
 
-        <Stack gap={0} px="xs" pb="xs">
+        <Stack gap={0} px="sm" pb="sm" className="chatbox-sidebar-footer">
           <Divider />
-          <Stack gap="xs" pt="xs" mb="xs">
-            <Button
-              variant="light"
-              fullWidth
-              radius="lg"
-              data-testid={TestId.sidebar.newChat}
-              onClick={handleCreateNewSession}
-            >
-              <ScalableIcon icon={IconCirclePlus} className="mr-2" />
-              {t('New Chat')}
-            </Button>
-            <Button
-              variant="light"
-              fullWidth
-              radius="lg"
-              data-testid={TestId.sidebar.newImage}
-              onClick={handleCreateNewPictureSession}
-            >
-              <ScalableIcon icon={IconPhotoPlus} className="mr-2" />
-              {t('Create Image')}
-            </Button>
-          </Stack>
-
-          {isSmallScreen ? (
-            <Flex gap="md" align="center">
-              <NavLink
-                c="chatbox-secondary"
-                className="rounded-lg"
-                label={t('My Copilots')}
-                leftSection={<ScalableIcon icon={IconMessageChatbot} size={20} />}
+          <Flex gap={4} pt="xs" align="center" justify="space-between" className="chatbox-sidebar-icon-nav">
+            <SidebarIconButton
+              label={t('My Copilots')}
+              icon={IconMessageChatbot}
+              onClick={() => {
+                navigate({ to: '/copilots' })
+                if (isSmallScreen) setShowSidebar(false)
+              }}
+            />
+            <SidebarIconButton
+              label={t('Settings')}
+              icon={IconSettingsFilled}
+              data-testid={TestId.sidebar.settingsTrigger}
+              onClick={() => {
+                navigateToSettings()
+                if (isSmallScreen) setShowSidebar(false)
+              }}
+            />
+            {!versionHook.isExceeded && (
+              <SidebarIconButton
+                label={t('Help')}
+                icon={IconHelpCircle}
                 onClick={() => {
-                  navigate({
-                    to: '/copilots',
-                  })
-                  setShowSidebar(false)
+                  navigate({ to: '/guide' })
+                  if (isSmallScreen) setShowSidebar(false)
                 }}
-                variant="light"
-                p="xs"
               />
-
-              {!versionHook.isExceeded && (
-                <ActionIcon
-                  variant="transparent"
-                  color="chatbox-secondary"
-                  size={24}
-                  onClick={() => {
-                    navigate({ to: '/guide' })
-                    setShowSidebar(false)
-                  }}
-                >
-                  <ScalableIcon icon={IconHelpCircle} size={20} />
-                </ActionIcon>
-              )}
-              <ActionIcon
-                data-testid={TestId.sidebar.settingsTrigger}
-                variant="transparent"
-                color="chatbox-secondary"
-                size={24}
-                onClick={() => {
-                  navigateToSettings()
-                  setShowSidebar(false)
-                }}
-              >
-                <ScalableIcon icon={IconSettingsFilled} size={20} />
-              </ActionIcon>
-
-              <SmallScreenAboutIcon versionHook={versionHook} navigate={navigate} setShowSidebar={setShowSidebar} />
-            </Flex>
-          ) : (
-            <>
-              <NavLink
-                c="chatbox-secondary"
-                className="rounded-lg"
-                label={t('My Copilots')}
-                leftSection={<ScalableIcon icon={IconMessageChatbot} size={20} />}
-                onClick={() => {
-                  navigate({
-                    to: '/copilots',
-                  })
-                  if (isSmallScreen) {
-                    setShowSidebar(false)
-                  }
-                }}
-                variant="light"
-                p="xs"
-              />
-              <NavLink
-                data-testid={TestId.sidebar.settingsTrigger}
-                c="chatbox-secondary"
-                className="rounded-lg"
-                label={t('Settings')}
-                leftSection={<ScalableIcon icon={IconSettingsFilled} size={20} />}
-                onClick={() => navigateToSettings()}
-                variant="light"
-                p="xs"
-              />
-              {!versionHook.isExceeded && (
-                <NavLink
-                  c="chatbox-secondary"
-                  className="rounded-lg"
-                  label={t('Help')}
-                  leftSection={<ScalableIcon icon={IconHelpCircle} size={20} />}
-                  onClick={() => navigate({ to: '/guide' })}
-                  variant="light"
-                  p="xs"
-                />
-              )}
-              {FORCE_ENABLE_DEV_PAGES && (
-                <NavLink
-                  c="chatbox-secondary"
-                  className="rounded-lg"
-                  label="Dev Tools"
-                  leftSection={<ScalableIcon icon={IconCode} size={20} />}
-                  onClick={() => navigate({ to: '/dev' })}
-                  variant="light"
-                  p="xs"
-                />
-              )}
-              <AboutNavLink versionHook={versionHook} navigate={navigate} />
-            </>
-          )}
+            )}
+            {FORCE_ENABLE_DEV_PAGES && (
+              <SidebarIconButton label="Dev Tools" icon={IconCode} onClick={() => navigate({ to: '/dev' })} />
+            )}
+            <AboutIconButton versionHook={versionHook} navigate={navigate} setShowSidebar={setShowSidebar} />
+          </Flex>
         </Stack>
         {!isSmallScreen && (
           <Box
@@ -371,6 +280,35 @@ export default function Sidebar() {
         )}
       </Stack>
     </SwipeableDrawer>
+  )
+}
+
+function SidebarIconButton({
+  label,
+  icon: Icon,
+  onClick,
+  ...props
+}: {
+  label: string
+  icon: typeof IconMessageChatbot
+  onClick: () => void
+  'data-testid'?: string
+}) {
+  return (
+    <Tooltip label={label} openDelay={500} withArrow>
+      <ActionIcon
+        {...props}
+        aria-label={label}
+        variant="subtle"
+        color="chatbox-secondary"
+        size={34}
+        radius="md"
+        onClick={onClick}
+        className="chatbox-sidebar-icon-button"
+      >
+        <ScalableIcon icon={Icon} size={19} />
+      </ActionIcon>
+    </Tooltip>
   )
 }
 
@@ -421,38 +359,7 @@ function useShowUpdateDot(versionHook: ReturnType<typeof useVersion>) {
   return isMobile ? versionHook.needCheckUpdate : updateStatus === 'downloaded'
 }
 
-function AboutNavLink({
-  versionHook,
-  navigate,
-}: {
-  versionHook: ReturnType<typeof useVersion>
-  navigate: ReturnType<typeof useNavigate>
-}) {
-  const { t } = useTranslation()
-  const showDot = useShowUpdateDot(versionHook)
-
-  return (
-    <NavLink
-      c="chatbox-tertiary"
-      className="rounded-lg"
-      label={
-        <Flex align="center" gap={6}>
-          <span>{`${t('About')} ${/\d/.test(versionHook.version) ? `(${versionHook.version})` : ''}`}</span>
-          {showDot && <Box w={8} h={8} miw={8} bg="chatbox-brand" style={{ borderRadius: '50%' }} />}
-        </Flex>
-      }
-      leftSection={<ScalableIcon icon={IconInfoCircle} size={20} />}
-      onClick={() => navigate({ to: '/about' })}
-      variant="light"
-      p="xs"
-    />
-  )
-}
-
-/**
- * Small screen About icon with dot indicator for mobile.
- */
-function SmallScreenAboutIcon({
+function AboutIconButton({
   versionHook,
   navigate,
   setShowSidebar,
@@ -461,24 +368,33 @@ function SmallScreenAboutIcon({
   navigate: ReturnType<typeof useNavigate>
   setShowSidebar: (v: boolean) => void
 }) {
+  const { t } = useTranslation()
+  const isSmallScreen = useIsSmallScreen()
   const showDot = useShowUpdateDot(versionHook)
 
   return (
-    <Box className="relative">
-      <ActionIcon
-        variant="transparent"
-        color="chatbox-secondary"
-        size={24}
-        onClick={() => {
-          navigate({ to: '/about' })
-          setShowSidebar(false)
-        }}
-      >
-        <ScalableIcon icon={IconInfoCircle} size={20} />
-      </ActionIcon>
-      {showDot && (
-        <Box w={8} h={8} bg="chatbox-brand" className="absolute -top-0.5 -right-0.5" style={{ borderRadius: '50%' }} />
-      )}
-    </Box>
+    <Tooltip
+      label={`${t('About')} ${/\d/.test(versionHook.version) ? `(${versionHook.version})` : ''}`}
+      openDelay={500}
+      withArrow
+    >
+      <Box className="relative">
+        <ActionIcon
+          aria-label={t('About')}
+          variant="subtle"
+          color="chatbox-tertiary"
+          size={34}
+          radius="md"
+          onClick={() => {
+            navigate({ to: '/about' })
+            if (isSmallScreen) setShowSidebar(false)
+          }}
+          className="chatbox-sidebar-icon-button"
+        >
+          <ScalableIcon icon={IconInfoCircle} size={19} />
+        </ActionIcon>
+        {showDot && <Box w={7} h={7} bg="chatbox-brand" className="absolute right-1 top-1 rounded-full" />}
+      </Box>
+    </Tooltip>
   )
 }

--- a/src/renderer/components/chat/MessageList.tsx
+++ b/src/renderer/components/chat/MessageList.tsx
@@ -477,7 +477,7 @@ const MessageList = forwardRef<MessageListRef, MessageListProps>((props, ref) =>
           {/* Virtuoso smooths appended items but snaps same-item height growth; the controller below owns both cases. */}
           <Virtuoso
             style={{ scrollbarGutter: 'stable' }}
-            className={platformType === 'win32' ? 'scrollbar-custom' : ''}
+            className={cn('chatbox-chat-scroll', platformType === 'win32' ? 'scrollbar-custom' : '')}
             data={renderItems}
             ref={virtuoso}
             followOutput={false}

--- a/src/renderer/components/layout/Header.tsx
+++ b/src/renderer/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 import NiceModal from '@ebay/nice-modal-react'
 import { ActionIcon, Flex, Text } from '@mantine/core'
 import type { Session } from '@shared/types'
-import { IconLayoutSidebarLeftExpand, IconMenu2 } from '@tabler/icons-react'
+import { IconLayoutSidebarLeftCollapse, IconLayoutSidebarLeftExpand, IconMenu2 } from '@tabler/icons-react'
 import clsx from 'clsx'
 import { PencilIcon } from 'lucide-react'
 import { useEffect } from 'react'
@@ -56,20 +56,25 @@ export default function Header(props: { session: Session }) {
         px="md"
         className={clsx('flex-none title-bar border-0', isSmallScreen ? 'bg-chatbox-background-primary' : '')}
       >
-        {(!showSidebar || isSmallScreen) && (
-          <Flex align="center" className={needRoomForMacWindowControls ? 'pl-20' : ''}>
-            <ActionIcon
-              className="controls"
-              variant="subtle"
-              size={isSmallScreen ? 24 : 20}
-              color={isSmallScreen ? 'chatbox-secondary' : 'chatbox-tertiary'}
-              mr="xs"
-              onClick={() => setShowSidebar(!showSidebar)}
-            >
-              {isSmallScreen ? <IconMenu2 /> : <IconLayoutSidebarLeftExpand />}
-            </ActionIcon>
-          </Flex>
-        )}
+        <Flex align="center" className={!showSidebar && needRoomForMacWindowControls ? 'pl-20' : ''}>
+          <ActionIcon
+            className="controls"
+            aria-label={t(showSidebar && !isSmallScreen ? 'Collapse' : 'Expand')}
+            variant="subtle"
+            size={isSmallScreen ? 24 : 20}
+            color={isSmallScreen ? 'chatbox-secondary' : 'chatbox-tertiary'}
+            mr="xs"
+            onClick={() => setShowSidebar(!showSidebar)}
+          >
+            {isSmallScreen ? (
+              <IconMenu2 />
+            ) : showSidebar ? (
+              <IconLayoutSidebarLeftCollapse />
+            ) : (
+              <IconLayoutSidebarLeftExpand />
+            )}
+          </ActionIcon>
+        </Flex>
 
         <Flex
           align="center"

--- a/src/renderer/components/layout/Page.tsx
+++ b/src/renderer/components/layout/Page.tsx
@@ -1,7 +1,8 @@
 import { ActionIcon, Box, Flex, Title } from '@mantine/core'
-import { IconLayoutSidebarLeftExpand, IconMenu2 } from '@tabler/icons-react'
+import { IconLayoutSidebarLeftCollapse, IconLayoutSidebarLeftExpand, IconMenu2 } from '@tabler/icons-react'
 import clsx from 'clsx'
 import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
 import useNeedRoomForWinControls from '@/hooks/useNeedRoomForWinControls'
 import { useIsSmallScreen } from '@/hooks/useScreenChange'
 import { useUIStore } from '@/stores/uiStore'
@@ -15,6 +16,7 @@ export type PageProps = {
 }
 
 export const Page: FC<PageProps> = ({ children, title, left, right }) => {
+  const { t } = useTranslation()
   const showSidebar = useUIStore((s) => s.showSidebar)
   const setShowSidebar = useUIStore((s) => s.setShowSidebar)
   const isSmallScreen = useIsSmallScreen()
@@ -27,21 +29,27 @@ export const Page: FC<PageProps> = ({ children, title, left, right }) => {
         px="md"
         className={clsx('title-bar', isSmallScreen ? 'bg-chatbox-background-primary' : '')}
       >
-        {left ||
-          ((!showSidebar || isSmallScreen) && (
-            <Flex align="center" className={needRoomForMacWindowControls ? 'pl-20' : ''}>
-              <ActionIcon
-                className="controls"
-                variant="subtle"
-                size={isSmallScreen ? 24 : 20}
-                color={isSmallScreen ? 'chatbox-secondary' : 'chatbox-tertiary'}
-                mr="xs"
-                onClick={() => setShowSidebar(!showSidebar)}
-              >
-                {isSmallScreen ? <IconMenu2 /> : <IconLayoutSidebarLeftExpand />}
-              </ActionIcon>
-            </Flex>
-          ))}
+        {left || (
+          <Flex align="center" className={!showSidebar && needRoomForMacWindowControls ? 'pl-20' : ''}>
+            <ActionIcon
+              className="controls"
+              aria-label={t(showSidebar && !isSmallScreen ? 'Collapse' : 'Expand')}
+              variant="subtle"
+              size={isSmallScreen ? 24 : 20}
+              color={isSmallScreen ? 'chatbox-secondary' : 'chatbox-tertiary'}
+              mr="xs"
+              onClick={() => setShowSidebar(!showSidebar)}
+            >
+              {isSmallScreen ? (
+                <IconMenu2 />
+              ) : showSidebar ? (
+                <IconLayoutSidebarLeftCollapse />
+              ) : (
+                <IconLayoutSidebarLeftExpand />
+              )}
+            </ActionIcon>
+          </Flex>
+        )}
 
         <Flex align="center" gap={'xxs'} flex={1} {...(isSmallScreen ? { justify: 'center', px: 'sm' } : {})}>
           {typeof title === 'string' ? (

--- a/src/renderer/components/layout/WindowControls.tsx
+++ b/src/renderer/components/layout/WindowControls.tsx
@@ -15,7 +15,7 @@ export const WindowControls: FC<FlexProps> = ({ className, ...otherProps }) => {
   const windowMaximized = useWindowMaximized()
   const platformType = useAtomValue(platformTypeAtom)
   return platformType === 'win32' || platformType === 'linux' ? (
-    <Flex align="center" className={clsx('controls self-start', className)} {...otherProps}>
+    <Flex align="center" className={clsx('controls', className)} {...otherProps}>
       <ControlButton label={t('Minimize') ?? ''} icon={IconMinus} onClick={() => platform.minimize()} />
       {!windowMaximized ? (
         <ControlButton label={t('Maximize') ?? ''} icon={IconSquare} onClick={() => platform.maximize()} />

--- a/src/renderer/components/settings/provider/ProviderList.tsx
+++ b/src/renderer/components/settings/provider/ProviderList.tsx
@@ -73,24 +73,24 @@ export function ProviderList({ providers, onAddProvider }: ProviderListProps) {
                 component="span"
                 align="center"
                 gap="xs"
-                p="md"
-                pr="xl"
-                py={isSmallScreen ? 'sm' : undefined}
+                p="sm"
+                pr="lg"
+                py={isSmallScreen ? 'xs' : 6}
                 c={provider.id === providerId ? 'chatbox-brand' : 'chatbox-secondary'}
                 bg={provider.id === providerId ? 'var(--chatbox-background-brand-secondary)' : 'transparent'}
                 className={clsx(
-                  'cursor-pointer select-none rounded-lg',
+                  'settings-sidebar-item cursor-pointer select-none rounded-lg',
                   provider.id === providerId ? '' : 'hover:!bg-chatbox-background-gray-secondary'
                 )}
               >
                 {provider.isCustom ? (
                   provider.iconUrl ? (
-                    <Image w={32} h={32} src={provider.iconUrl} alt={provider.name} />
+                    <Image w={24} h={24} src={provider.iconUrl} alt={provider.name} />
                   ) : (
-                    <CustomProviderIcon providerId={provider.id} providerName={provider.name} size={32} />
+                    <CustomProviderIcon providerId={provider.id} providerName={provider.name} size={24} />
                   )
                 ) : (
-                  <ProviderIconImage providerId={provider.id} size={32} />
+                  <ProviderIconImage providerId={provider.id} size={24} />
                 )}
 
                 <Text

--- a/src/renderer/modals/Settings.tsx
+++ b/src/renderer/modals/Settings.tsx
@@ -76,10 +76,15 @@ export const SettingsModal: FC<SettingsModalProps> = (props) => {
       }}
       transitionProps={{ transition: 'fade-up' }}
     >
-      <Flex flex="0 0 auto" className="title-bar border-0 border-b border-chatbox-border-primary border-solid">
+      <Flex
+        h={48}
+        align="center"
+        flex="0 0 48px"
+        className="title-bar border-0 border-b border-chatbox-border-primary border-solid"
+      >
         <div className={clsx('flex-[1_1_0]', needRoomForMacWindowControls ? 'min-w-16' : '')} />
-        <Flex p="sm" align="center" w={'100%'} maw={1200} gap="xs">
-          <Title order={3} flex={1}>
+        <Flex px="sm" align="center" h="100%" w={'100%'} maw={1200} gap="xs">
+          <Title order={4} fz={18} lh="24px" fw={600} lineClamp={1} flex={1}>
             {t('Settings')}
           </Title>
 
@@ -90,10 +95,10 @@ export const SettingsModal: FC<SettingsModalProps> = (props) => {
             className="controls"
             color="chatbox-secondary"
             variant="light"
-            h={36}
-            w={36}
+            h={32}
+            w={32}
             p={0}
-            radius="lg"
+            radius="md"
             onClick={onClose}
             autoFocus={false}
           >

--- a/src/renderer/routes/__root.tsx
+++ b/src/renderer/routes/__root.tsx
@@ -353,13 +353,9 @@ function Root() {
           }}
         >
           <Box
-            className="title-bar absolute inset-x-0 top-0 hidden sm:block"
-            sx={{ height: showSidebar ? '10px' : '5px' }}
-          />
-          <Box
             className="h-full box-border"
             sx={{
-              padding: { xs: 0, sm: showSidebar ? '10px 10px 10px 0' : '5px' },
+              padding: { xs: 0, sm: showSidebar ? '0 10px 10px 0' : '0 5px 5px' },
               transition: (theme) =>
                 theme.transitions.create('padding', {
                   easing: showSidebar ? theme.transitions.easing.easeOut : theme.transitions.easing.sharp,
@@ -370,12 +366,12 @@ function Root() {
             }}
           >
             <Box
-              className={`h-full overflow-hidden border-[0.5px] border-solid border-chatbox-border-primary ${
+              className={`h-full overflow-hidden ${
                 hasBackgroundImage ? 'bg-transparent' : 'bg-chatbox-background-primary'
               }`}
               sx={{
-                borderRadius: { xs: 0, sm: '16px' },
-                boxShadow: { xs: 'none', sm: '0 0 22px rgba(0, 0, 0, 0.11)' },
+                borderRadius: 0,
+                boxShadow: 'none',
               }}
             >
               <ErrorBoundary name="main">

--- a/src/renderer/routes/guide/index.tsx
+++ b/src/renderer/routes/guide/index.tsx
@@ -23,6 +23,7 @@ import {
   IconCheck,
   IconChevronRight,
   IconLanguage,
+  IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
   IconMenu2,
   IconPlayerSkipForward,
@@ -241,23 +242,28 @@ function GuidePage() {
     <Stack h="100%" gap={0} className="bg-chatbox-background-primary">
       {/* Header */}
       <Flex h={48} align="center" px="md" className="flex-none title-bar">
-        {(!showSidebar || isSmallScreen) && (
-          <Flex align="center" className={needRoomForMacWindowControls ? 'pl-20' : ''}>
-            <ActionIcon
-              className="controls"
-              variant="subtle"
-              size={isSmallScreen ? 24 : 20}
-              color={isSmallScreen ? 'chatbox-secondary' : 'chatbox-tertiary'}
-              mr="xs"
-              onClick={() => setShowSidebar(!showSidebar)}
-            >
-              {isSmallScreen ? <IconMenu2 /> : <IconLayoutSidebarLeftExpand />}
-            </ActionIcon>
-          </Flex>
-        )}
+        <Flex align="center" className={!showSidebar && needRoomForMacWindowControls ? 'pl-20' : ''}>
+          <ActionIcon
+            className="controls"
+            aria-label={showSidebar && !isSmallScreen ? t('Collapse') : t('Expand')}
+            variant="subtle"
+            size={isSmallScreen ? 24 : 20}
+            color={isSmallScreen ? 'chatbox-secondary' : 'chatbox-tertiary'}
+            mr="xs"
+            onClick={() => setShowSidebar(!showSidebar)}
+          >
+            {isSmallScreen ? (
+              <IconMenu2 />
+            ) : showSidebar ? (
+              <IconLayoutSidebarLeftCollapse />
+            ) : (
+              <IconLayoutSidebarLeftExpand />
+            )}
+          </ActionIcon>
+        </Flex>
 
         <Flex align="center" gap="xxs" flex={1} {...(isSmallScreen ? { justify: 'center', pl: 28, pr: 8 } : {})}>
-          <Title order={4} fz={!isSmallScreen ? 20 : undefined} lineClamp={1}>
+          <Title order={4} fz={!isSmallScreen ? 18 : undefined} lh="24px" fw={600} lineClamp={1}>
             {t('Getting Started')}
           </Title>
         </Flex>

--- a/src/renderer/routes/settings/route.tsx
+++ b/src/renderer/routes/settings/route.tsx
@@ -175,25 +175,25 @@ export function SettingsRoot() {
               <Flex
                 component="span"
                 gap="xs"
-                p="md"
-                pr="xl"
-                py={isSmallScreen ? 'sm' : undefined}
+                p="sm"
+                pr="lg"
+                py={isSmallScreen ? 'xs' : undefined}
                 align="center"
                 c={item.key === key ? 'chatbox-brand' : 'chatbox-secondary'}
                 bg={item.key === key ? 'var(--chatbox-background-brand-secondary)' : 'transparent'}
                 className={clsx(
-                  ' cursor-pointer select-none rounded-lg',
+                  'settings-sidebar-item cursor-pointer select-none rounded-lg',
                   item.key === key ? '' : 'hover:!bg-chatbox-background-gray-secondary'
                 )}
               >
-                <Box component="span" flex="0 0 auto" w={20} h={20} mr="xs">
+                <Box component="span" flex="0 0 auto" w={18} h={18} mr="xs">
                   {item.icon}
                 </Box>
                 <Text
                   flex={1}
                   lineClamp={1}
                   span={true}
-                  className={`!text-inherit ${isSmallScreen ? 'min-h-[32px] leading-[32px]' : ''}`}
+                  className={`!text-inherit ${isSmallScreen ? 'min-h-[28px] leading-[28px]' : ''}`}
                 >
                   {'noTranslate' in item && item.noTranslate ? item.label : t(item.label)}
                 </Text>
@@ -214,21 +214,21 @@ export function SettingsRoot() {
               <Flex
                 component="span"
                 gap="xs"
-                p="md"
-                pr="xl"
-                py="sm"
+                p="sm"
+                pr="lg"
+                py="xs"
                 align="center"
                 c={'chatbox-secondary'}
-                className={clsx(' cursor-pointer select-none rounded-lg')}
+                className={clsx('settings-sidebar-item cursor-pointer select-none rounded-lg')}
               >
-                <Box component="span" flex="0 0 auto" w={20} h={20} mr="xs">
+                <Box component="span" flex="0 0 auto" w={18} h={18} mr="xs">
                   <ScalableIcon icon={IconInfoCircle} size={20} />
                 </Box>
                 <Text
                   flex={1}
                   lineClamp={1}
                   span={true}
-                  className={`!text-inherit ${isSmallScreen ? 'min-h-[32px] leading-[32px]' : ''}`}
+                  className={`!text-inherit ${isSmallScreen ? 'min-h-[28px] leading-[28px]' : ''}`}
                 >
                   {t('About')}
                 </Text>

--- a/src/renderer/static/globals.css
+++ b/src/renderer/static/globals.css
@@ -313,8 +313,125 @@ html[data-need-room-for-windows-controls="true"] .pswp__top-bar {
   width: 12px !important;
 }
 
+/* Keep scroll affordances available without making them compete with the content. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(134 142 150 / 0.24) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: rgb(134 142 150 / 0.22);
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+
+*:hover::-webkit-scrollbar-thumb {
+  background: rgb(134 142 150 / 0.34);
+  background-clip: padding-box;
+}
+
+[data-mantine-color-scheme="dark"] * {
+  scrollbar-color: rgb(206 212 218 / 0.24) transparent;
+}
+
+[data-mantine-color-scheme="dark"] *::-webkit-scrollbar-thumb {
+  background: rgb(206 212 218 / 0.22);
+  background-clip: padding-box;
+}
+
+[data-mantine-color-scheme="dark"] *:hover::-webkit-scrollbar-thumb {
+  background: rgb(206 212 218 / 0.34);
+  background-clip: padding-box;
+}
+
 *::-webkit-scrollbar-corner {
   background-color: transparent;
+}
+
+.chatbox-sidebar {
+  background: var(--chatbox-background-primary);
+  border-inline-end: 1px solid color-mix(in srgb, var(--chatbox-border-primary), transparent 28%);
+}
+
+.chatbox-sidebar-primary-actions {
+  flex: 0 0 auto;
+}
+
+.chatbox-sidebar-primary-action {
+  justify-content: flex-start;
+  min-height: 38px;
+  color: var(--chatbox-tint-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  text-align: left;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
+}
+
+.chatbox-sidebar-primary-action:hover {
+  color: var(--chatbox-tint-primary);
+  background: var(--chatbox-background-secondary);
+}
+
+.chatbox-sidebar-footer {
+  flex: 0 0 auto;
+  color: var(--chatbox-tint-tertiary);
+}
+
+.chatbox-sidebar-icon-nav {
+  min-height: 42px;
+}
+
+.chatbox-sidebar-icon-button {
+  color: var(--chatbox-tint-tertiary);
+  transition:
+    color 140ms ease,
+    background-color 140ms ease;
+}
+
+.chatbox-sidebar-icon-button:hover,
+.chatbox-sidebar-icon-button:focus-visible {
+  color: var(--chatbox-tint-primary);
+  background: var(--chatbox-background-secondary);
+}
+
+.chatbox-chat-scroll {
+  scrollbar-color: rgb(134 142 150 / 0.2) transparent;
+  scrollbar-width: thin;
+}
+
+[data-mantine-color-scheme="dark"] .chatbox-chat-scroll {
+  scrollbar-color: rgb(206 212 218 / 0.2) transparent;
+}
+
+.settings-sidebar-item {
+  min-height: 38px;
+}
+
+@media (max-width: 640px) {
+  .chatbox-sidebar {
+    border-inline-end: 0;
+  }
+
+  .chatbox-sidebar-primary-actions {
+    padding-inline: var(--chatbox-spacing-md);
+  }
+
+  .chatbox-sidebar-footer {
+    padding-inline: var(--chatbox-spacing-md);
+  }
 }
 
 div[data-vaul-handle] {

--- a/src/renderer/static/index.css
+++ b/src/renderer/static/index.css
@@ -153,6 +153,44 @@ html[data-theme="light"] {
   }
 }
 
+/* The message list uses a quieter scrollbar than the rest of the app. These
+   rules live after the theme defaults so the chat surface keeps this treatment
+   in both light and dark mode. */
+.chatbox-chat-scroll::-webkit-scrollbar {
+  width: 8px !important;
+  height: 8px !important;
+}
+
+.chatbox-chat-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+html[data-theme="light"] .chatbox-chat-scroll::-webkit-scrollbar-thumb {
+  background-color: rgb(134 142 150 / 0.18);
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+
+html[data-theme="light"] .chatbox-chat-scroll.scrollbar-scrolling::-webkit-scrollbar-thumb,
+html[data-theme="light"] .chatbox-chat-scroll:hover::-webkit-scrollbar-thumb {
+  background-color: rgb(134 142 150 / 0.3);
+  background-clip: padding-box;
+}
+
+html[data-theme="dark"] .chatbox-chat-scroll::-webkit-scrollbar-thumb {
+  background-color: rgb(206 212 218 / 0.18);
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+
+html[data-theme="dark"] .chatbox-chat-scroll.scrollbar-scrolling::-webkit-scrollbar-thumb,
+html[data-theme="dark"] .chatbox-chat-scroll:hover::-webkit-scrollbar-thumb {
+  background-color: rgb(206 212 218 / 0.3);
+  background-clip: padding-box;
+}
+
 .App {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary\n- Restructure the sidebar with compact primary actions, conversation list, and icon-only footer navigation.\n- Align the right-side title bar with native/window controls, keep the collapse button at the main content edge, and preserve a separate macOS sidebar safe area.\n- Remove chat surface framing, soften scrollbars, compact settings/provider navigation rows, and reduce the settings header title size.\n\n## Validation\n- TypeScript check: passed.\n- Production build: passed via electron-vite build.\n- Targeted formatting: passed.\n- Full lint currently reports existing diagnostics outside this change, including src/main and integration tests.\n- Full test suite: 260 files passed; the existing migration suite has a setup/schema failure, and context-management has 2 existing failed assertions.