### PR TITLE
fix: preserve empty MCP environment variables

### DIFF
--- a/src/renderer/components/settings/mcp/utils.test.ts
+++ b/src/renderer/components/settings/mcp/utils.test.ts
@@ -15,6 +15,25 @@ function createFormValues(command: string): MCPServerConfigFormValues {
 }
 
 describe('MCP stdio command form conversion', () => {
+  it('preserves environment variables with empty values across edits', () => {
+    const initialConfig: MCPServerConfig = {
+      id: 'server-1',
+      name: 'Test server',
+      enabled: true,
+      transport: {
+        type: 'stdio',
+        command: 'server',
+        args: [],
+        env: {
+          EMPTY: '',
+          TOKEN: 'value',
+        },
+      },
+    }
+
+    expect(getConfigFromFormValues(getFormValuesFromConfig(initialConfig))).toEqual(initialConfig)
+  })
+
   it('preserves a quoted Windows path across repeated edits', () => {
     const initialValues = createFormValues(String.raw`uv --directory "C:\\path\\to\\" run xx.py`)
     const initialConfig = getConfigFromFormValues(initialValues)

--- a/src/renderer/components/settings/mcp/utils.ts
+++ b/src/renderer/components/settings/mcp/utils.ts
@@ -11,7 +11,7 @@ const envUtils = {
       if (eqIndex === -1) continue
       const key = line.slice(0, eqIndex)
       const value = line.slice(eqIndex + 1)
-      if (key && value && key.trim() && value.trim()) {
+      if (key.trim()) {
         result[key.trim()] = value.trim()
       }
     }


### PR DESCRIPTION
### Description

Preserve MCP stdio environment variables whose values are empty strings when editing an existing server configuration.

The environment parser previously required both the key and value to be non-empty after trimming. As a result, a valid entry such as `EMPTY=` disappeared after the configuration was converted to form values and saved again.

The parser now accepts any entry with a non-empty key while preserving an empty value. A regression test verifies that configurations containing both empty and non-empty environment variables survive a complete form conversion round trip.

### Additional Notes

Validation completed:

- targeted Vitest suite: 3 tests passed
- Biome checks for both changed files
- TypeScript type checking

### Screenshots

Not applicable; this change corrects configuration serialization behavior without changing the interface.

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

- [x] I have read and agree with the above statement.