### PR TITLE
fix: restore editable field context menu

### DIFF
--- a/src/main/locales.ts
+++ b/src/main/locales.ts
@@ -67,6 +67,10 @@ const translations = {
     en: 'Paste as Plain Text',
     zh: '粘贴为文本',
   },
+  SelectAll: {
+    en: 'Select All',
+    zh: '全选',
+  },
   ReplaceWith: {
     en: 'Replace with',
     zh: '替换成',

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -1,0 +1,129 @@
+import type { BrowserWindow, ContextMenuParams, Event } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  buildFromTemplate: vi.fn(),
+  popup: vi.fn(),
+  setApplicationMenu: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getLocale: vi.fn(() => 'en'),
+    quit: vi.fn(),
+  },
+  Menu: {
+    buildFromTemplate: mocks.buildFromTemplate,
+    setApplicationMenu: mocks.setApplicationMenu,
+  },
+  MenuItem: class {},
+  shell: {
+    openExternal: vi.fn(),
+  },
+}))
+
+import MenuBuilder from './menu'
+
+type ContextMenuHandler = (event: Event, props: ContextMenuParams) => void
+
+function createWindow() {
+  let contextMenuHandler: ContextMenuHandler | undefined
+  const mainWindow = {
+    webContents: {
+      inspectElement: vi.fn(),
+      on: vi.fn((eventName: string, handler: ContextMenuHandler) => {
+        if (eventName === 'context-menu') {
+          contextMenuHandler = handler
+        }
+      }),
+      reload: vi.fn(),
+      replaceMisspelling: vi.fn(),
+    },
+  } as unknown as BrowserWindow
+
+  return {
+    getContextMenuHandler: () => {
+      if (!contextMenuHandler) {
+        throw new Error('context-menu handler was not registered')
+      }
+      return contextMenuHandler
+    },
+    mainWindow,
+  }
+}
+
+describe('desktop context menu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.buildFromTemplate.mockReturnValue({ popup: mocks.popup })
+  })
+
+  it('allows paste and select all in an editable field without a text selection', () => {
+    const { getContextMenuHandler, mainWindow } = createWindow()
+    new MenuBuilder(mainWindow).buildMenu()
+    const event = { preventDefault: vi.fn() } as unknown as Event
+
+    getContextMenuHandler()(event, {
+      dictionarySuggestions: [],
+      isEditable: true,
+      selectionText: '',
+      x: 12,
+      y: 34,
+    } as unknown as ContextMenuParams)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(mocks.buildFromTemplate).toHaveBeenCalledTimes(2)
+    const contextMenuTemplate = mocks.buildFromTemplate.mock.calls[1][0]
+    expect(contextMenuTemplate).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ enabled: false, role: 'copy' }),
+        expect.objectContaining({ enabled: false, role: 'cut' }),
+        expect.objectContaining({ enabled: true, role: 'paste' }),
+        expect.objectContaining({ role: 'selectAll' }),
+      ])
+    )
+    expect(mocks.popup).toHaveBeenCalledWith({ window: mainWindow })
+  })
+
+  it('keeps copy and cut available when editable text is selected', () => {
+    const { getContextMenuHandler, mainWindow } = createWindow()
+    new MenuBuilder(mainWindow).buildMenu()
+
+    getContextMenuHandler()(
+      { preventDefault: vi.fn() } as unknown as Event,
+      {
+        dictionarySuggestions: [],
+        isEditable: true,
+        selectionText: 'selected text',
+        x: 12,
+        y: 34,
+      } as unknown as ContextMenuParams
+    )
+
+    const contextMenuTemplate = mocks.buildFromTemplate.mock.calls[1][0]
+    expect(contextMenuTemplate).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ enabled: true, role: 'copy' }),
+        expect.objectContaining({ enabled: true, role: 'cut' }),
+      ])
+    )
+  })
+
+  it('keeps the context menu hidden outside editable fields when nothing is selected', () => {
+    const { getContextMenuHandler, mainWindow } = createWindow()
+    new MenuBuilder(mainWindow).buildMenu()
+    const event = { preventDefault: vi.fn() } as unknown as Event
+
+    getContextMenuHandler()(event, {
+      dictionarySuggestions: [],
+      isEditable: false,
+      selectionText: '',
+      x: 12,
+      y: 34,
+    } as unknown as ContextMenuParams)
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(mocks.buildFromTemplate).toHaveBeenCalledOnce()
+    expect(mocks.popup).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,4 +1,4 @@
-import { app, type BrowserWindow, Menu, MenuItem, type MenuItemConstructorOptions, shell } from 'electron'
+import { app, type BrowserWindow, Menu, type MenuItemConstructorOptions, shell } from 'electron'
 import Locale from './locales'
 
 interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
@@ -19,17 +19,32 @@ export default class MenuBuilder {
     this.mainWindow.webContents.on('context-menu', (event, props) => {
       const hasSelection = Boolean(props.selectionText?.trim())
 
-      // 没有选中文本：禁止右键菜单
-      if (!hasSelection) {
+      // 没有选中文本且不是可编辑区域：禁止右键菜单
+      if (!hasSelection && !props.isEditable) {
         event.preventDefault()
         return
       }
       const items: (Electron.MenuItem | Electron.MenuItemConstructorOptions)[] = [
-        { role: 'copy', label: locale.t('Copy'), accelerator: 'CmdOrCtrl+C' },
-        { role: 'cut', label: locale.t('Cut'), accelerator: 'CmdOrCtrl+X' },
-        { role: 'paste', label: locale.t('Paste'), accelerator: 'CmdOrCtrl+V' },
-        { role: 'pasteAndMatchStyle', label: locale.t('PasteAsPlainText'), accelerator: 'CmdOrCtrl+Shift+V' },
-        // { type: 'separator' },
+        { role: 'copy', label: locale.t('Copy'), accelerator: 'CmdOrCtrl+C', enabled: hasSelection },
+        {
+          role: 'cut',
+          label: locale.t('Cut'),
+          accelerator: 'CmdOrCtrl+X',
+          enabled: hasSelection && props.isEditable,
+        },
+        { role: 'paste', label: locale.t('Paste'), accelerator: 'CmdOrCtrl+V', enabled: props.isEditable },
+        {
+          role: 'pasteAndMatchStyle',
+          label: locale.t('PasteAsPlainText'),
+          accelerator: 'CmdOrCtrl+Shift+V',
+          enabled: props.isEditable,
+        },
+        { type: 'separator' },
+        {
+          role: 'selectAll',
+          label: locale.t('SelectAll'),
+          accelerator: 'CmdOrCtrl+A',
+        },
         // { role: 'resetZoom', label: locale.t('ResetZoom'), accelerator: 'CmdOrCtrl+0' },
         // { role: 'zoomIn', label: locale.t('ZoomIn'), accelerator: 'CmdOrCtrl+=' },
         // { role: 'zoomOut', label: locale.t('ZoomOut'), accelerator: 'CmdOrCtrl+-' },


### PR DESCRIPTION
## 问题

公开版桌面端在提示词输入框没有文本选区时会直接拦截右键菜单，导致用户无法通过鼠标粘贴或全选。

Fixes https://github.com/chatboxai/chatbox/issues/3853

## 根因

Electron 主进程的 `context-menu` 处理器仅根据 `selectionText` 决定是否显示菜单。空输入框没有文本选区，即使 `isEditable` 为真也会被当作非交互区域处理。

## 修复

- 可编辑区域即使没有文本选区也显示右键菜单。
- 根据文本选区和可编辑状态启用或禁用复制、剪切、粘贴和纯文本粘贴。
- 补齐带本地化文案和快捷键的“全选”菜单项。
- 覆盖空可编辑区域、有选区可编辑区域和无选区非编辑区域的回归测试。

## 验证

- `pnpm exec vitest run src/main/menu.test.ts`（3 个测试通过）
- `pnpm check`
- `pnpm exec biome format --write src/main/locales.ts src/main/menu.ts src/main/menu.test.ts`
- `git diff --check`
