### PR TITLE
feat: add direct OpenAI-compatible audio transcription

### DIFF
--- a/packages/chatbox-core/src/domain/settings/settings-defaults.ts
+++ b/packages/chatbox-core/src/domain/settings/settings-defaults.ts
@@ -85,6 +85,12 @@ export function createDefaultSettings(): Settings {
         queritTimeRange: 'none',
         searxngBaseUrl: '',
       },
+      speechToText: {
+        enabled: false,
+        baseUrl: '',
+        model: 'FunAudioLLM/SenseVoiceSmall',
+        apiKey: '',
+      },
       knowledgeBase: {
         models: {
           embedding: undefined,

--- a/packages/chatbox-core/src/domain/settings/settings-schema.ts
+++ b/packages/chatbox-core/src/domain/settings/settings-schema.ts
@@ -337,6 +337,14 @@ const ExtensionSettingsSchema = z.object({
     queritTimeRange: z.string().nullable().optional(),
     searxngBaseUrl: z.string().optional(),
   }),
+  speechToText: z
+    .object({
+      enabled: z.boolean().catch(false),
+      baseUrl: z.string().catch(''),
+      model: z.string().catch('FunAudioLLM/SenseVoiceSmall'),
+      apiKey: z.string().catch(''),
+    })
+    .optional(),
   knowledgeBase: z
     .object({
       models: z.object({

--- a/src/renderer/components/InputBox/InputBox.tsx
+++ b/src/renderer/components/InputBox/InputBox.tsx
@@ -25,6 +25,7 @@ import {
   IconCirclePlus,
   IconFilePencil,
   IconFolder,
+  IconMicrophone,
   IconPhoto,
   IconPlayerStopFilled,
   IconPlus,
@@ -78,6 +79,7 @@ import {
 } from '@/packages/model-registry'
 import * as picUtils from '@/packages/pic_utils'
 import { skillsController, subscribeSkillsChanged } from '@/packages/skills/controller'
+import { transcribeOpenAICompatibleAudio } from '@/packages/speech-to-text/openai-compatible'
 import { seedExactDraftTokens } from '@/packages/token-estimation'
 import platform from '@/platform'
 import { StorageKeyGenerator } from '@/storage/StoreStorage'
@@ -264,6 +266,7 @@ const InputBox = forwardRef<InputBoxRef, InputBoxProps>(
     const [hasTextContent, setHasTextContent] = useState(false)
     const draftMessageIdRef = useRef<string | undefined>(undefined)
     const enabledSkillNames = useSettingsStore((state) => state.skills.enabledSkillNames)
+    const speechToText = useSettingsStore((state) => state.extension.speechToText)
     const [inputSkills, setInputSkills] = useState<Array<{ name: string; description: string }>>([])
     const [inputSkillsLoading, setInputSkillsLoading] = useState(false)
     const [skillCommandQuery, setSkillCommandQuery] = useState<string | null>(null)
@@ -526,6 +529,8 @@ const InputBox = forwardRef<InputBoxRef, InputBoxProps>(
 
     const pictureInputRef = useRef<HTMLInputElement | null>(null)
     const fileInputRef = useRef<HTMLInputElement | null>(null)
+    const audioInputRef = useRef<HTMLInputElement | null>(null)
+    const [transcribingAudio, setTranscribingAudio] = useState(false)
 
     // Check if any preprocessing is in progress
     const isPreprocessing = useMemo(() => {
@@ -1336,6 +1341,27 @@ const InputBox = forwardRef<InputBoxRef, InputBoxProps>(
     const onFileUploadClick = () => {
       fileInputRef.current?.click()
     }
+    const onAudioTranscriptionClick = () => {
+      audioInputRef.current?.click()
+    }
+    const onAudioTranscriptionChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const [file] = Array.from(event.currentTarget.files ?? [])
+      event.currentTarget.value = ''
+      if (!file || !speechToText?.baseUrl.trim() || !speechToText.model.trim()) {
+        toastActions.add(t('Configure a speech-to-text service before transcribing audio.'))
+        return
+      }
+
+      setTranscribingAudio(true)
+      try {
+        const text = await transcribeOpenAICompatibleAudio(speechToText, file)
+        messageInputFieldRef.current?.setValue((value) => `${value}${value.trim() ? '\n\n' : ''}${text}`)
+      } catch (error) {
+        toastActions.add((error as Error).message || t('Audio transcription failed'))
+      } finally {
+        setTranscribingAudio(false)
+      }
+    }
 
     const onImageDeleteClick = async (picKey: string) => {
       setPreConstructedMessage((prev) => ({
@@ -1847,10 +1873,24 @@ const InputBox = forwardRef<InputBoxRef, InputBoxProps>(
                 multiple
                 accept={isAgentModeActive ? undefined : getFileAcceptString()}
               />
+              <input
+                type="file"
+                ref={audioInputRef}
+                className="hidden"
+                accept="audio/*"
+                onChange={(event) => void onAudioTranscriptionChange(event)}
+              />
 
               {/* Left Group: Tool Buttons */}
               <Flex align="center" gap={0}>
-                <AttachmentMenu onImageUploadClick={onImageUploadClick} onFileUploadClick={onFileUploadClick} t={t} />
+                <AttachmentMenu
+                  onImageUploadClick={onImageUploadClick}
+                  onFileUploadClick={onFileUploadClick}
+                  onAudioTranscriptionClick={onAudioTranscriptionClick}
+                  speechToTextEnabled={Boolean(speechToText?.enabled) && !isSmallScreen}
+                  transcribingAudio={transcribingAudio}
+                  t={t}
+                />
 
                 <ReasoningControlButton
                   provider={model?.provider}
@@ -2106,8 +2146,18 @@ const InputBox = forwardRef<InputBoxRef, InputBoxProps>(
 const AttachmentMenu: React.FC<{
   onImageUploadClick: () => void
   onFileUploadClick: () => void
+  onAudioTranscriptionClick: () => void
+  speechToTextEnabled: boolean
+  transcribingAudio: boolean
   t: (key: string) => string
-}> = ({ onImageUploadClick, onFileUploadClick, t }) => {
+}> = ({
+  onImageUploadClick,
+  onFileUploadClick,
+  onAudioTranscriptionClick,
+  speechToTextEnabled,
+  transcribingAudio,
+  t,
+}) => {
   const isSmallScreen = useIsSmallScreen()
   const toolbarIconSize = isSmallScreen ? 22 : 18
   return (
@@ -2146,6 +2196,15 @@ const AttachmentMenu: React.FC<{
         >
           {t('Select File')}
         </Menu.Item>
+        {speechToTextEnabled && (
+          <Menu.Item
+            leftSection={<IconMicrophone size={16} />}
+            onClick={onAudioTranscriptionClick}
+            disabled={transcribingAudio}
+          >
+            {transcribingAudio ? t('Transcribing audio...') : t('Transcribe Audio')}
+          </Menu.Item>
+        )}
       </Menu.Dropdown>
     </Menu>
   )

--- a/src/renderer/packages/speech-to-text/openai-compatible.test.ts
+++ b/src/renderer/packages/speech-to-text/openai-compatible.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { transcribeOpenAICompatibleAudio } from './openai-compatible'
+
+describe('transcribeOpenAICompatibleAudio', () => {
+  it('posts an OpenAI-compatible multipart request without forcing a JSON content type', async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ text: 'recognized text' }), { status: 200 }))
+    const audio = new File(['audio'], 'meeting.webm', { type: 'audio/webm' })
+
+    await expect(
+      transcribeOpenAICompatibleAudio(
+        {
+          baseUrl: 'http://127.0.0.1:8000/v1/',
+          model: 'FunAudioLLM/SenseVoiceSmall',
+          apiKey: ' local-token ',
+        },
+        audio,
+        request
+      )
+    ).resolves.toBe('recognized text')
+
+    const [url, init] = request.mock.calls[0]
+    expect(url).toBe('http://127.0.0.1:8000/v1/audio/transcriptions')
+    expect(init.method).toBe('POST')
+    expect(init.headers).toEqual({ Authorization: 'Bearer local-token' })
+    expect(init.headers).not.toHaveProperty('Content-Type')
+    expect(init.body.get('model')).toBe('FunAudioLLM/SenseVoiceSmall')
+    expect(init.body.get('file')).toBeInstanceOf(File)
+  })
+})

--- a/src/renderer/packages/speech-to-text/openai-compatible.ts
+++ b/src/renderer/packages/speech-to-text/openai-compatible.ts
@@ -1,0 +1,39 @@
+export interface OpenAICompatibleTranscriptionConfig {
+  baseUrl: string
+  model: string
+  apiKey?: string
+}
+
+type FetchLike = typeof fetch
+
+function getTranscriptionUrl(baseUrl: string): string {
+  const normalized = baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '')
+  return `${normalized}/v1/audio/transcriptions`
+}
+
+export async function transcribeOpenAICompatibleAudio(
+  config: OpenAICompatibleTranscriptionConfig,
+  file: File,
+  request: FetchLike = fetch
+): Promise<string> {
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('model', config.model.trim())
+
+  const apiKey = config.apiKey?.trim()
+  const response = await request(getTranscriptionUrl(config.baseUrl), {
+    method: 'POST',
+    headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+    body: formData,
+  })
+  const payload = await response.json()
+
+  if (!response.ok) {
+    throw new Error(payload?.error?.message ?? 'Audio transcription failed')
+  }
+  if (typeof payload?.text !== 'string' || !payload.text.trim()) {
+    throw new Error('The transcription service returned no text')
+  }
+
+  return payload.text
+}

--- a/src/renderer/routes/settings/route.tsx
+++ b/src/renderer/routes/settings/route.tsx
@@ -13,6 +13,7 @@ import {
   IconInfoCircle,
   IconKeyboard,
   IconMessages,
+  IconMicrophone,
   IconRobotFace,
   IconSparkles,
   IconWand,
@@ -51,6 +52,15 @@ const ITEMS = [
     label: 'Web Search',
     icon: <IconWorldWww className="w-full h-full" />,
   },
+  ...(platform.type === 'mobile'
+    ? []
+    : [
+        {
+          key: 'speech-to-text',
+          label: 'Speech to Text',
+          icon: <IconMicrophone className="w-full h-full" />,
+        },
+      ]),
   ...(featureFlags.mcp
     ? [
         {

--- a/src/renderer/routes/settings/speech-to-text.tsx
+++ b/src/renderer/routes/settings/speech-to-text.tsx
@@ -1,0 +1,60 @@
+import { PasswordInput, Stack, Switch, Text, TextInput, Title } from '@mantine/core'
+import { createFileRoute } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+import { useSettingsStore } from '@/stores/settingsStore'
+
+export const Route = createFileRoute('/settings/speech-to-text')({
+  component: RouteComponent,
+})
+
+export function RouteComponent() {
+  const { t } = useTranslation()
+  const extension = useSettingsStore((state) => state.extension)
+  const setSettings = useSettingsStore((state) => state.setSettings)
+  const speechToText = extension.speechToText ?? {
+    enabled: false,
+    baseUrl: '',
+    model: 'FunAudioLLM/SenseVoiceSmall',
+    apiKey: '',
+  }
+  const update = (updates: Partial<typeof speechToText>) =>
+    setSettings({
+      extension: {
+        ...extension,
+        speechToText: { ...speechToText, ...updates },
+      },
+    })
+
+  return (
+    <Stack p="md" gap="xl" maw={560}>
+      <Title order={5}>{t('Speech to Text')}</Title>
+      <Switch
+        checked={speechToText.enabled}
+        label={t('Enable audio transcription')}
+        onChange={(event) => update({ enabled: event.currentTarget.checked })}
+      />
+      <TextInput
+        value={speechToText.baseUrl}
+        label={t('OpenAI-compatible Base URL')}
+        placeholder="http://127.0.0.1:8000/v1"
+        onChange={(event) => update({ baseUrl: event.currentTarget.value })}
+      />
+      <TextInput
+        value={speechToText.model}
+        label={t('Model')}
+        placeholder="FunAudioLLM/SenseVoiceSmall"
+        onChange={(event) => update({ model: event.currentTarget.value })}
+      />
+      <PasswordInput
+        value={speechToText.apiKey}
+        label={t('API Key')}
+        onChange={(event) => update({ apiKey: event.currentTarget.value })}
+      />
+      <Text size="xs" c="chatbox-gray">
+        {t(
+          'Audio is sent directly to this service. The service must allow browser CORS requests. Audio transcription is currently available on desktop and web only.'
+        )}
+      </Text>
+    </Stack>
+  )
+}


### PR DESCRIPTION
## Summary
- add opt-in desktop/web audio transcription settings for any OpenAI-compatible `/v1/audio/transcriptions` service
- send multipart audio directly to the configured endpoint; no Chatbox public proxy is used
- append returned transcript to the active draft without sending it

## Service examples
The configured endpoint can be self-hosted FunASR, SenseVoice, or another compatible service. Browser-accessible endpoints must allow CORS.

## Validation
- `pnpm check`
- `pnpm exec vitest run src/renderer/packages/speech-to-text/openai-compatible.test.ts`
- `pnpm run build`

Related to #3759. Keep #3759 open for maintainers and users to confirm the requested workflow.