### PR TITLE
fix(guide): flush final streamed content

### DIFF
--- a/src/renderer/routes/guide/-hooks/useStreamParser.test.ts
+++ b/src/renderer/routes/guide/-hooks/useStreamParser.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GuideUIMessage } from './types'
+import { parseStreamResponse, type StreamParserCallbacks } from './useStreamParser'
+
+vi.mock('@/components/Confetti', () => ({ confetti: vi.fn() }))
+vi.mock('@/stores/onboardingStore', () => ({
+  onboardingStore: {
+    getState: () => ({ markCompleted: vi.fn() }),
+  },
+}))
+vi.mock('@/stores/premiumActions', () => ({ activate: vi.fn() }))
+
+function createReader(chunks: Uint8Array[]): ReadableStreamDefaultReader<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk)
+      controller.close()
+    },
+  }).getReader()
+}
+
+function createHarness() {
+  let messages: GuideUIMessage[] = [
+    {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '',
+      parts: [],
+      isStreaming: true,
+    },
+  ]
+  const pendingUpdateRef: StreamParserCallbacks['pendingUpdateRef'] = { current: null }
+  const setMessages: StreamParserCallbacks['setMessages'] = (update) => {
+    messages = typeof update === 'function' ? update(messages) : update
+  }
+  const callbacks: StreamParserCallbacks = {
+    setMessages,
+    setOnboardingStep: vi.fn(),
+    pendingUpdateRef,
+    pendingTimeouts: new Set(),
+    markGuideCompleted: vi.fn(async () => undefined),
+    t: ((key: string) => key) as StreamParserCallbacks['t'],
+  }
+
+  return {
+    callbacks,
+    getMessage: () => messages[0],
+    getMessages: () => messages,
+    pendingUpdateRef,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('parseStreamResponse', () => {
+  it('flushes and parses the final unterminated stream line at EOF', async () => {
+    const decoderSpy = vi.spyOn(TextDecoder.prototype, 'decode')
+    const payload = [
+      'data: {"type":"tool-input-start","toolCallId":"tool-1","toolName":"show_new_chat_button"}',
+      'data: {"type":"tool-output-available","toolCallId":"tool-1","output":{"label":"尾部"}}',
+    ].join('\n')
+    const encoded = new TextEncoder().encode(payload)
+    const multibyteStart = encoded.lastIndexOf(0xe5)
+    const reader = createReader([encoded.slice(0, multibyteStart + 1), encoded.slice(multibyteStart + 1)])
+    const { callbacks, getMessage } = createHarness()
+
+    await parseStreamResponse(reader, callbacks)
+
+    expect(getMessage()).toMatchObject({
+      isStreaming: false,
+      parts: [
+        {
+          type: 'tool-show_new_chat_button',
+          toolCallId: 'tool-1',
+          toolName: 'show_new_chat_button',
+          state: 'result',
+          result: { label: '尾部' },
+        },
+      ],
+    })
+    expect(decoderSpy).toHaveBeenLastCalledWith()
+  })
+
+  it('commits a pending animation-frame update before completing the stream', async () => {
+    let pendingFrame: FrameRequestCallback | undefined
+    const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
+      pendingFrame = callback
+      return 0
+    })
+    const cancelAnimationFrameMock = vi.fn()
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock)
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameMock)
+
+    const reader = createReader([
+      new TextEncoder().encode(
+        'data: {"type":"text-delta","delta":"final"}\ndata: {"type":"text-delta","delta":" answer"}\n'
+      ),
+    ])
+    const { callbacks, getMessage, pendingUpdateRef } = createHarness()
+
+    await parseStreamResponse(reader, callbacks)
+
+    expect(getMessage()).toMatchObject({
+      content: 'final answer',
+      parts: [{ type: 'text', text: 'final answer' }],
+      isStreaming: false,
+    })
+    expect(requestAnimationFrameMock).toHaveBeenCalledOnce()
+    expect(cancelAnimationFrameMock).toHaveBeenCalledWith(0)
+    expect(pendingUpdateRef.current).toBeNull()
+
+    pendingFrame?.(0)
+    expect(getMessage()).toMatchObject({
+      content: 'final answer',
+      parts: [{ type: 'text', text: 'final answer' }],
+      isStreaming: false,
+    })
+  })
+
+  it('flushes pending content and invalidates the stale frame when reading aborts', async () => {
+    let pendingFrame: FrameRequestCallback | undefined
+    const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
+      pendingFrame = callback
+      return 17
+    })
+    const cancelAnimationFrameMock = vi.fn()
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock)
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameMock)
+
+    const abortError = new Error('aborted')
+    abortError.name = 'AbortError'
+    const read = vi
+      .fn()
+      .mockResolvedValueOnce({
+        done: false,
+        value: new TextEncoder().encode('data: {"type":"text-delta","delta":"partial answer"}\n'),
+      })
+      .mockRejectedValueOnce(abortError)
+    const reader = { read } as unknown as ReadableStreamDefaultReader<Uint8Array>
+    const { callbacks, getMessage, getMessages, pendingUpdateRef } = createHarness()
+    let thrown: unknown
+
+    try {
+      await parseStreamResponse(reader, callbacks)
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(getMessage()).toMatchObject({
+      content: 'partial answer',
+      parts: [{ type: 'text', text: 'partial answer' }],
+      isStreaming: true,
+    })
+    expect(thrown).toBe(abortError)
+    expect(cancelAnimationFrameMock).toHaveBeenCalledWith(17)
+    expect(pendingUpdateRef.current).toBeNull()
+
+    callbacks.setMessages((prev) => [
+      { ...prev[0], isStreaming: false },
+      {
+        id: 'assistant-2',
+        role: 'assistant',
+        content: 'new answer',
+        parts: [{ type: 'text', text: 'new answer' }],
+        isStreaming: true,
+      },
+    ])
+    pendingFrame?.(0)
+
+    expect(getMessages()[1]).toMatchObject({
+      content: 'new answer',
+      parts: [{ type: 'text', text: 'new answer' }],
+      isStreaming: true,
+    })
+  })
+})

--- a/src/renderer/routes/guide/-hooks/useStreamParser.ts
+++ b/src/renderer/routes/guide/-hooks/useStreamParser.ts
@@ -71,14 +71,31 @@ export async function parseStreamResponse(
     })
   }
 
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
+  const cancelPendingUpdate = () => {
+    if (pendingUpdateRef.current !== null) {
+      cancelAnimationFrame(pendingUpdateRef.current)
+      pendingUpdateRef.current = null
+    }
+  }
 
-    buffer += decoder.decode(value, { stream: true })
+  while (true) {
+    let readResult: ReadableStreamReadResult<Uint8Array>
+    try {
+      readResult = await reader.read()
+    } catch (error) {
+      cancelPendingUpdate()
+      updateStreamingMessage()
+      throw error
+    }
+    const { done, value } = readResult
+    buffer += done ? decoder.decode() : decoder.decode(value, { stream: true })
     const lines = buffer.split('\n')
     // Keep the last incomplete line in buffer
     buffer = lines.pop() || ''
+    if (done && buffer) {
+      lines.push(buffer)
+      buffer = ''
+    }
 
     for (const line of lines) {
       const trimmedLine = line.trim()
@@ -116,11 +133,13 @@ export async function parseStreamResponse(
           }
 
           // Batch updates using requestAnimationFrame to reduce re-renders
-          if (!pendingUpdateRef.current) {
-            pendingUpdateRef.current = requestAnimationFrame(() => {
+          if (pendingUpdateRef.current === null) {
+            const frameId = requestAnimationFrame(() => {
+              if (pendingUpdateRef.current !== frameId) return
               pendingUpdateRef.current = null
               updateStreamingMessage()
             })
+            pendingUpdateRef.current = frameId
           }
         } else if (event.type === 'tool-input-start' && event.toolCallId && event.toolName) {
           // Tool call start - create the tool part
@@ -193,7 +212,11 @@ export async function parseStreamResponse(
         console.debug('Skipping non-JSON line:', trimmedLine)
       }
     }
+
+    if (done) break
   }
+
+  cancelPendingUpdate()
 
   // Mark streaming as complete
   setMessages((prev) => {
@@ -203,6 +226,8 @@ export async function parseStreamResponse(
         ...prev.slice(0, lastIdx),
         {
           ...prev[lastIdx],
+          content: accumulatedContent,
+          parts: [...accumulatedParts],
           isStreaming: false,
         },
       ]


### PR DESCRIPTION
### Description

Fix the guide stream parser so content is not lost when a response ends before the next animation-frame update or without a trailing newline.

- Flush the `TextDecoder` and parse the final buffered line at EOF.
- Commit accumulated content before marking the streaming message complete.
- Cancel and invalidate pending animation-frame updates on normal completion or read errors so a stale callback cannot overwrite later state.
- Add regression coverage for split multibyte UTF-8, frame ID `0`, and aborted reads.

### Additional Notes

Validation on Node 22.23.2 and pnpm 10.33.0:

- `pnpm test`: 4,174 passed, 87 skipped
- `pnpm check`
- `biome ci` on the changed files
- `git diff --check`

### Screenshots

N/A (no visual changes).

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[x] I have read and agree with the above statement.
