### PR TITLE
fix: keep focus in an open dialog when the window regains focus

### DIFF
--- a/src/renderer/hooks/useShortcut.test.tsx
+++ b/src/renderer/hooks/useShortcut.test.tsx
@@ -6,6 +6,8 @@ import useShortcut from './useShortcut'
 
 const mocks = vi.hoisted(() => ({
   startNewThread: vi.fn(() => Promise.resolve()),
+  focusMessageInput: vi.fn(),
+  windowFocusedHandler: undefined as (() => void) | undefined,
 }))
 
 vi.mock('jotai', () => ({
@@ -36,8 +38,12 @@ vi.mock('../packages/navigator', () => ({
 
 vi.mock('../platform', () => ({
   default: {
+    type: 'desktop',
     isDesktopLike: false,
-    onWindowFocused: vi.fn(),
+    onWindowFocused: (handler: () => void) => {
+      mocks.windowFocusedHandler = handler
+      return vi.fn()
+    },
     onWindowShow: () => vi.fn(),
   },
 }))
@@ -67,7 +73,8 @@ vi.mock('../stores/settingsStore', () => ({
 }))
 
 vi.mock('./dom', () => ({
-  focusMessageInput: vi.fn(),
+  messageInputID: 'message-input',
+  focusMessageInput: mocks.focusMessageInput,
 }))
 
 vi.mock('./useScreenChange', () => ({
@@ -77,6 +84,8 @@ vi.mock('./useScreenChange', () => ({
 describe('useShortcut', () => {
   afterEach(() => {
     vi.clearAllMocks()
+    document.body.innerHTML = ''
+    mocks.windowFocusedHandler = undefined
   })
 
   test('handles keyboard shortcuts through the settings projection', () => {
@@ -88,5 +97,49 @@ describe('useShortcut', () => {
 
     expect(mocks.startNewThread).toHaveBeenCalledWith('session-1')
     unmount()
+  })
+
+  describe('auto-focus on window focus', () => {
+    test('focuses the composer when nothing else owns focus', () => {
+      const { unmount } = renderHook(() => useShortcut())
+
+      act(() => mocks.windowFocusedHandler?.())
+
+      expect(mocks.focusMessageInput).toHaveBeenCalledTimes(1)
+      unmount()
+    })
+
+    test('leaves focus in an open dialog', () => {
+      document.body.innerHTML = '<div role="dialog"><textarea id="edit-message"></textarea></div>'
+      const { unmount } = renderHook(() => useShortcut())
+
+      act(() => mocks.windowFocusedHandler?.())
+
+      expect(mocks.focusMessageInput).not.toHaveBeenCalled()
+      unmount()
+    })
+
+    test('leaves focus in another editable control', () => {
+      document.body.innerHTML = '<input id="thread-name" />'
+      document.getElementById('thread-name')?.focus()
+      const { unmount } = renderHook(() => useShortcut())
+
+      act(() => mocks.windowFocusedHandler?.())
+
+      expect(document.activeElement?.id).toBe('thread-name')
+      expect(mocks.focusMessageInput).not.toHaveBeenCalled()
+      unmount()
+    })
+
+    test('still focuses the composer when the composer itself had focus', () => {
+      document.body.innerHTML = '<textarea id="message-input"></textarea>'
+      document.getElementById('message-input')?.focus()
+      const { unmount } = renderHook(() => useShortcut())
+
+      act(() => mocks.windowFocusedHandler?.())
+
+      expect(mocks.focusMessageInput).toHaveBeenCalledTimes(1)
+      unmount()
+    })
   })
 })

--- a/src/renderer/hooks/useShortcut.test.tsx
+++ b/src/renderer/hooks/useShortcut.test.tsx
@@ -119,6 +119,32 @@ describe('useShortcut', () => {
       unmount()
     })
 
+    test('ignores a dialog that is mounted but closed', () => {
+      // MUI Modal with `keepMounted` (SearchDialog in __root.tsx) keeps the paper in
+      // the DOM and hides the root when closed.
+      document.body.innerHTML =
+        '<div role="presentation" aria-hidden="true" style="visibility: hidden">' +
+        '<div role="dialog"><input id="search-input" /></div></div>'
+      const { unmount } = renderHook(() => useShortcut())
+
+      act(() => mocks.windowFocusedHandler?.())
+
+      expect(mocks.focusMessageInput).toHaveBeenCalledTimes(1)
+      unmount()
+    })
+
+    test('still leaves focus in an open dialog next to a closed one', () => {
+      document.body.innerHTML =
+        '<div role="presentation" style="display: none"><div role="dialog"></div></div>' +
+        '<div role="dialog"><textarea id="edit-message"></textarea></div>'
+      const { unmount } = renderHook(() => useShortcut())
+
+      act(() => mocks.windowFocusedHandler?.())
+
+      expect(mocks.focusMessageInput).not.toHaveBeenCalled()
+      unmount()
+    })
+
     test('leaves focus in another editable control', () => {
       document.body.innerHTML = '<input id="thread-name" />'
       document.getElementById('thread-name')?.focus()

--- a/src/renderer/hooks/useShortcut.tsx
+++ b/src/renderer/hooks/useShortcut.tsx
@@ -40,6 +40,20 @@ function getRouteSessionId() {
   return sessionRouteMatch?.[1] ? decodeURIComponent(sessionRouteMatch[1]) : null
 }
 
+// When the window regains focus the OS restores it to whatever had it before
+// (the message edit dialog's textarea, a rename input). Moving it to the
+// composer in that state throws the user out of what they were editing (#3830).
+function shouldAutoFocusMessageInput() {
+  if (document.querySelector('[role="dialog"]')) {
+    return false
+  }
+  const active = document.activeElement
+  if (!active || active.id === dom.messageInputID) {
+    return true
+  }
+  return !(active.tagName === 'TEXTAREA' || active.tagName === 'INPUT' || (active as HTMLElement).isContentEditable)
+}
+
 export default function useShortcut() {
   const isSmallScreen = useIsSmallScreen()
 
@@ -49,7 +63,7 @@ export default function useShortcut() {
     }
     const focusMessageInput = () => {
       // 大屏幕下，窗口显示时自动聚焦输入框
-      if (!isSmallScreen) {
+      if (!isSmallScreen && shouldAutoFocusMessageInput()) {
         dom.focusMessageInput()
       }
     }

--- a/src/renderer/hooks/useShortcut.tsx
+++ b/src/renderer/hooks/useShortcut.tsx
@@ -43,8 +43,28 @@ function getRouteSessionId() {
 // When the window regains focus the OS restores it to whatever had it before
 // (the message edit dialog's textarea, a rename input). Moving it to the
 // composer in that state throws the user out of what they were editing (#3830).
+function isRendered(element: Element) {
+  for (let node: Element | null = element; node; node = node.parentElement) {
+    if (node.getAttribute('aria-hidden') === 'true' || (node as HTMLElement).hidden) {
+      return false
+    }
+    const style = window.getComputedStyle(node)
+    if (style.display === 'none' || style.visibility === 'hidden') {
+      return false
+    }
+  }
+  return true
+}
+
+// A dialog can be mounted while closed (MUI `keepMounted`, e.g. SearchDialog in
+// __root.tsx): its `role="dialog"` node stays in the DOM under a hidden ancestor,
+// so only a rendered dialog counts as open.
+function hasOpenDialog() {
+  return Array.from(document.querySelectorAll('[role="dialog"]')).some(isRendered)
+}
+
 function shouldAutoFocusMessageInput() {
-  if (document.querySelector('[role="dialog"]')) {
+  if (hasOpenDialog()) {
     return false
   }
   const active = document.activeElement


### PR DESCRIPTION
### Description

Fixes #3830.

On desktop, `useShortcut` registers `platform.onWindowFocused(focusMessageInput)` and the handler calls `dom.focusMessageInput()` unconditionally. When the user switches to another window and comes back via the taskbar, the OS first restores focus to whatever had it before — the message edit dialog's textarea, a thread rename input — and the handler immediately moves it to the composer. With the edit dialog open that leaves the user typing into the composer behind the modal.

The change adds one guard in `src/renderer/hooks/useShortcut.tsx`: the auto-focus is skipped while a dialog is open or while another editable control (`textarea`, `input`, contenteditable) has focus. A dialog counts as open when its `[role="dialog"]` node is rendered: dialogs that stay mounted while closed (SearchDialog in `__root.tsx` is a MUI Dialog with `keepMounted`, whose paper sits under a root hidden with `visibility: hidden`; closed Mantine Popover dropdowns are `display: none`) are ignored by walking up the ancestors and checking `aria-hidden="true"`, the `hidden` attribute, `display: none` and `visibility: hidden`. Nothing else changes: with no dialog open and nothing focused the composer still gets focus, and it keeps getting focus when it had it itself.

`src/renderer/hooks/useShortcut.test.tsx` gains six cases for the window-focus path (composer focused when nothing owns focus; left alone with a dialog open; composer focused despite a mounted-but-closed keepMounted dialog; left alone with an open dialog next to a closed one; left alone with another editable control focused; still focused when the composer itself had focus). The two "left alone" cases fail on `main`, and the keepMounted case fails on the first revision of this PR; all pass with the change. The platform mock now reports `type: 'desktop'` so the `onWindowFocused` registration actually runs under test, and the `./dom` mock exposes `messageInputID`.

Checks run locally (Windows 11, Node 22.23, pnpm 10.33):

- `pnpm exec vitest run src/renderer/hooks/useShortcut.test.tsx` — 7 passed
- `pnpm exec biome lint` / `biome format` on the two files — no new findings (the four floating-promise warnings are on pre-existing lines)
- `pnpm check` — clean

Manual check on Windows 11 with the dev build (`pnpm start`): send a message, open its edit dialog, switch to another window, return via the taskbar. Control run first with `useShortcut.tsx` checked out from `main` (renderer hot-reloaded): focus lands in the composer behind the modal, even though the dialog is a focus-trapping Mantine modal. Same steps with this change: focus stays in the edit dialog's textarea and typing continues there.

Second check after review (`pnpm start:cdp`, window minimised and restored from a script, `document.activeElement` read over CDP, window wider than the `sm` breakpoint so the desktop path runs): with nothing open the DOM holds two hidden `role="dialog"` nodes and the composer receives focus on return; with the edit dialog open and its textarea focused, focus stays in the textarea and the dialog stays open. The first revision of this PR left `document.body` focused in the no-dialog case, which is the regression the review pointed out.

### Additional Notes

`onWindowShow` shares the same handler, so a window restored from the tray behaves the same way. The `Ctrl+I` / `Ctrl+E` shortcuts still focus the composer explicitly; they are user actions, not an OS focus restore, and are untouched.

### Screenshots

N/A — focus behaviour, described in the steps above.

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[x] I have read and agree with the above statement.


