### PR TITLE
fix(context): avoid media-driven cache churn and configure Anthropic TTL

### DIFF
--- a/packages/chatbox-core/src/domain/settings/anthropic-cache-settings.test.ts
+++ b/packages/chatbox-core/src/domain/settings/anthropic-cache-settings.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { SettingsSchema } from './settings-schema'
+
+const cacheSettings = SettingsSchema.pick({ anthropicCacheTtl: true })
+
+describe('Anthropic cache settings', () => {
+  it('keeps five-minute caching for existing settings', () => {
+    expect(cacheSettings.parse({})).toEqual({ anthropicCacheTtl: '5m' })
+  })
+
+  it('persists both supported TTL values', () => {
+    for (const anthropicCacheTtl of ['5m', '1h']) {
+      expect(cacheSettings.parse(JSON.parse(JSON.stringify({ anthropicCacheTtl })))).toEqual({ anthropicCacheTtl })
+    }
+  })
+
+  it('falls back safely for corrupt or unsupported TTL values', () => {
+    for (const anthropicCacheTtl of ['24h', null, 3600, {}]) {
+      expect(cacheSettings.parse({ anthropicCacheTtl })).toEqual({ anthropicCacheTtl: '5m' })
+    }
+  })
+})

--- a/packages/chatbox-core/src/domain/settings/settings-defaults.ts
+++ b/packages/chatbox-core/src/domain/settings/settings-defaults.ts
@@ -52,6 +52,7 @@ export function createDefaultSettings(): Settings {
     autoGenerateTitle: true,
     autoCompaction: true,
     compactionThreshold: 0.6,
+    anthropicCacheTtl: '5m',
     pauseOnToolCallLimit: true,
     autoLaunch: false,
     autoUpdate: true,

--- a/packages/chatbox-core/src/domain/settings/settings-schema.ts
+++ b/packages/chatbox-core/src/domain/settings/settings-schema.ts
@@ -564,6 +564,7 @@ export const SettingsSchema = GlobalSessionSettingsSchema.extend({
 
   autoCompaction: z.boolean().default(true),
   compactionThreshold: z.number().min(0.4).max(0.9).default(0.6),
+  anthropicCacheTtl: z.enum(['5m', '1h']).default('5m').catch('5m'),
 
   // Global default for the tool-call-limit confirmation. Individual sessions
   // can override it via SessionSettingsSchema.pauseOnToolCallLimit.

--- a/src/renderer/i18n/locales/en/translation.json
+++ b/src/renderer/i18n/locales/en/translation.json
@@ -1,4 +1,8 @@
 {
+  "Anthropic prompt cache duration": "Anthropic prompt cache duration",
+  "5 minutes (default)": "5 minutes (default)",
+  "1 hour": "1 hour",
+  "Applies to Claude API, custom Anthropic providers and Anthropic models in Chatbox AI. One-hour cache writes cost more and require support from your provider or proxy. Changing the duration does not prevent cache misses when the context changes.": "Applies to Claude API, custom Anthropic providers and Anthropic models in Chatbox AI. One-hour cache writes cost more and require support from your provider or proxy. Changing the duration does not prevent cache misses when the context changes.",
   " for free now!": " for free now!",
   "(Remaining/Total)": "(Remaining/Total)",
   ") — Detailed feature documentation\n- 🆘 [Help Center](": ") — Detailed feature documentation\n- 🆘 [Help Center](",

--- a/src/renderer/i18n/locales/ru/translation.json
+++ b/src/renderer/i18n/locales/ru/translation.json
@@ -1,4 +1,8 @@
 {
+  "Anthropic prompt cache duration": "Срок хранения кеша промпта Anthropic",
+  "5 minutes (default)": "5 минут (по умолчанию)",
+  "1 hour": "1 час",
+  "Applies to Claude API, custom Anthropic providers and Anthropic models in Chatbox AI. One-hour cache writes cost more and require support from your provider or proxy. Changing the duration does not prevent cache misses when the context changes.": "Для Claude API, пользовательских провайдеров Anthropic и моделей Anthropic в Chatbox AI. Запись часового кеша дороже и требует поддержки провайдера или прокси. Увеличение срока хранения не предотвращает потерю совпадения кеша при изменении контекста.",
   " for free now!": " бесплатно прямо сейчас!",
   "(Remaining/Total)": "(Осталось/Всего)",
   ") — Detailed feature documentation\n- 🆘 [Help Center](": ") — подробная документация по функциям\n- 🆘 [Центр справки](",

--- a/src/renderer/routes/settings/chat.tsx
+++ b/src/renderer/routes/settings/chat.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, FileButton, Flex, Slider, Stack, Switch, Text, Textarea, Title } from '@mantine/core'
+import { Box, Button, FileButton, Flex, Select, Slider, Stack, Switch, Text, Textarea, Title } from '@mantine/core'
 import { TestId } from '@shared/automation/testids'
 import { chatSessionSettings, getDefaultPrompt } from '@shared/defaults'
 import { MAX_TOOL_CALLS_BEFORE_CONFIRMATION } from '@shared/utils/tool-call-limit-pause'
@@ -537,6 +537,22 @@ function ContextManagementSection() {
   return (
     <Stack gap="xl">
       <Text fw="600">{t('Context Management')}</Text>
+
+      <Select
+        label={t('Anthropic prompt cache duration')}
+        description={t(
+          'Applies to Claude API, custom Anthropic providers and Anthropic models in Chatbox AI. One-hour cache writes cost more and require support from your provider or proxy. Changing the duration does not prevent cache misses when the context changes.'
+        )}
+        value={settings.anthropicCacheTtl ?? '5m'}
+        data={[
+          { value: '5m', label: t('5 minutes (default)') },
+          { value: '1h', label: t('1 hour') },
+        ]}
+        allowDeselect={false}
+        onChange={(value) => {
+          if (value === '5m' || value === '1h') setSettings({ anthropicCacheTtl: value })
+        }}
+      />
 
       {/* Auto Compaction Toggle */}
       <Stack gap="sm">

--- a/src/shared/models/anthropic-cache-wire.test.ts
+++ b/src/shared/models/anthropic-cache-wire.test.ts
@@ -1,0 +1,72 @@
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { generateText, type ModelMessage, streamText } from 'ai'
+import { describe, expect, it } from 'vitest'
+import { addAnthropicCacheControl } from './anthropic-cache'
+
+const messages: ModelMessage[] = [
+  { role: 'system', content: 'Stable instructions' },
+  { role: 'user', content: 'First turn' },
+  { role: 'assistant', content: [{ type: 'text', text: 'Answer' }] },
+  { role: 'user', content: 'Next turn' },
+]
+
+const responseMessage = {
+  id: 'msg_test',
+  type: 'message',
+  role: 'assistant',
+  model: 'claude-sonnet-4-5',
+  content: [{ type: 'text', text: 'OK' }],
+  stop_reason: 'end_turn',
+  stop_sequence: null,
+  usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+}
+
+function streamResponse(): Response {
+  const events = [
+    { type: 'message_start', message: { ...responseMessage, content: [], stop_reason: null } },
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'OK' } },
+    { type: 'content_block_stop', index: 0 },
+    { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 1 } },
+    { type: 'message_stop' },
+  ]
+  return new Response(events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(''), {
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+
+describe('Anthropic cache TTL wire serialization', () => {
+  for (const ttl of ['5m', '1h'] as const) {
+    for (const streaming of [false, true]) {
+      it(`sends ${ttl} breakpoints with stream=${streaming}`, async () => {
+        const bodies: Array<{
+          system: Array<{ cache_control?: unknown }>
+          messages: Array<{ content: Array<{ cache_control?: unknown }> }>
+        }> = []
+        const provider = createAnthropic({
+          apiKey: 'test-key-not-a-secret',
+          baseURL: 'https://example.invalid/v1',
+          fetch: (_url, init) => {
+            bodies.push(JSON.parse(String(init?.body)))
+            return Promise.resolve(streaming ? streamResponse() : Response.json(responseMessage))
+          },
+        })
+        const options = {
+          model: provider('claude-sonnet-4-5'),
+          messages: addAnthropicCacheControl(messages, ttl),
+          maxOutputTokens: 16,
+          maxRetries: 0,
+        }
+        const text = streaming ? await streamText(options).text : (await generateText(options)).text
+        expect(text).toBe('OK')
+        expect(bodies).toHaveLength(1)
+        const body = bodies[0]
+        const controls = [...body.system, ...body.messages.flatMap((message) => message.content)]
+          .map((part) => part.cache_control)
+          .filter(Boolean)
+        const expected = { type: 'ephemeral', ...(ttl === '1h' ? { ttl: '1h' } : {}) }
+        expect(controls).toEqual([expected, expected, expected])
+      })
+    }
+  }
+})

--- a/src/shared/models/anthropic-cache.test.ts
+++ b/src/shared/models/anthropic-cache.test.ts
@@ -9,6 +9,30 @@ function hasCacheControl(msg: ModelMessage): boolean {
 }
 
 describe('addAnthropicCacheControl', () => {
+  it('requests one-hour TTL consistently at every selected breakpoint without mutating history', () => {
+    const messages: ModelMessage[] = [
+      { role: 'system', content: 'system' },
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: [{ type: 'text', text: 'answer' }] },
+      { role: 'user', content: 'second' },
+    ]
+    const result = addAnthropicCacheControl(messages, '1h')
+    for (const index of [0, 1, 3]) {
+      expect(result[index].providerOptions?.anthropic?.cacheControl).toEqual({ type: 'ephemeral', ttl: '1h' })
+      expect(messages[index].providerOptions).toBeUndefined()
+    }
+    expect(hasCacheControl(result[2])).toBe(false)
+  })
+
+  it('keeps the legacy wire options for the default five-minute TTL', () => {
+    const messages: ModelMessage[] = [
+      { role: 'system', content: 'system' },
+      { role: 'user', content: 'hello' },
+    ]
+    expect(addAnthropicCacheControl(messages, '5m')).toEqual(addAnthropicCacheControl(messages))
+    expect(addAnthropicCacheControl(messages)[0].providerOptions?.anthropic?.cacheControl).toEqual(cacheControl)
+  })
+
   it('returns empty array unchanged', () => {
     expect(addAnthropicCacheControl([])).toEqual([])
   })

--- a/src/shared/models/anthropic-cache.ts
+++ b/src/shared/models/anthropic-cache.ts
@@ -1,16 +1,19 @@
 import type { ModelMessage } from 'ai'
 
+export type AnthropicCacheTtl = '5m' | '1h'
+
 /**
  * Add ephemeral cache control breakpoints for Anthropic prompt caching.
  * Places up to 3 breakpoints for optimal prefix caching:
- * 1. System message (constant prefix, always cache-hit)
+ * 1. System message (stable prefix when instructions are unchanged)
  * 2. Second-to-last user message (previous turn's breakpoint, cache-hit on this turn)
  * 3. Last message (creates new cache prefix for the next turn)
  *
- * Works with both direct Anthropic API and AWS Bedrock.
+ * Used by direct/custom Anthropic Messages and Anthropic-routed Chatbox AI.
+ * A one-hour TTL requires upstream support and has a higher cache-write price.
  * See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
  */
-export function addAnthropicCacheControl(messages: ModelMessage[]): ModelMessage[] {
+export function addAnthropicCacheControl(messages: ModelMessage[], ttl: AnthropicCacheTtl = '5m'): ModelMessage[] {
   if (messages.length === 0) {
     return messages
   }
@@ -47,7 +50,8 @@ export function addAnthropicCacheControl(messages: ModelMessage[]): ModelMessage
         ...msg.providerOptions,
         anthropic: {
           ...(msg.providerOptions?.anthropic as Record<string, unknown> | undefined),
-          cacheControl: { type: 'ephemeral' },
+          // Omit the default TTL for compatibility with existing relays.
+          cacheControl: { type: 'ephemeral', ...(ttl === '1h' ? { ttl: '1h' } : {}) },
         },
       },
     }

--- a/src/shared/models/context-message-tokens.test.ts
+++ b/src/shared/models/context-message-tokens.test.ts
@@ -1,0 +1,82 @@
+import type { ModelMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+import {
+  estimateModelMessageTokens,
+  estimateToolOutputTokens,
+  MEDIA_PART_ESTIMATE_TOKENS,
+} from './context-message-tokens'
+
+function imageMessage(image: string | Uint8Array | URL): ModelMessage {
+  return { role: 'user', content: [{ type: 'image', image, mediaType: 'image/png' }] }
+}
+
+describe('multimodal pressure estimates', () => {
+  it('does not count base64, data URLs, binary buffers or remote URLs as image text', () => {
+    const small = estimateModelMessageTokens(imageMessage('AA=='))
+    for (const image of [
+      'A'.repeat(3_000_000),
+      `data:image/png;base64,${'A'.repeat(3_000_000)}`,
+      new Uint8Array(3_000_000),
+      new URL('https://example.invalid/image.png'),
+    ]) {
+      expect(estimateModelMessageTokens(imageMessage(image))).toBe(small)
+    }
+    expect(small).toBeGreaterThanOrEqual(MEDIA_PART_ESTIMATE_TOKENS)
+  })
+
+  it('does not serialize media buffers to estimate them', () => {
+    const bytes = new Uint8Array(10)
+    Object.defineProperty(bytes, 'toJSON', {
+      value: () => {
+        throw new Error('must not serialize media')
+      },
+    })
+    expect(estimateModelMessageTokens(imageMessage(bytes))).toBe(estimateModelMessageTokens(imageMessage('AA==')))
+  })
+
+  it('uses a bounded allowance for file/audio parts while retaining text weight', () => {
+    const message = (data: string): ModelMessage => ({
+      role: 'user',
+      content: [
+        { type: 'file', data, mediaType: 'audio/wav' },
+        { type: 'text', text: 'x'.repeat(40_000) },
+      ],
+    })
+    expect(estimateModelMessageTokens(message('A'.repeat(3_000_000)))).toBe(estimateModelMessageTokens(message('AA==')))
+    expect(estimateModelMessageTokens(message('AA=='))).toBeGreaterThan(10_000)
+  })
+
+  it('counts plain text and arbitrary JSON tool results in full', () => {
+    expect(estimateToolOutputTokens({ type: 'text', value: 'x'.repeat(40_000) })).toBe(10_000)
+    expect(estimateToolOutputTokens({ type: 'json', value: { data: 'x'.repeat(40_000) } })).toBeGreaterThan(10_000)
+    expect(estimateModelMessageTokens({ role: 'system', content: 'x'.repeat(40_000) })).toBeGreaterThan(10_000)
+  })
+
+  it('estimates typed media inside tool output without its encoded payload', () => {
+    const output = (data: string) => ({
+      type: 'content' as const,
+      value: [
+        { type: 'text' as const, text: 'x'.repeat(4_000) },
+        { type: 'image-data' as const, data, mediaType: 'image/png' },
+      ],
+    })
+    expect(estimateToolOutputTokens(output('A'.repeat(3_000_000)))).toBe(estimateToolOutputTokens(output('AA==')))
+    expect(estimateToolOutputTokens(output('AA=='))).toBeGreaterThan(MEDIA_PART_ESTIMATE_TOKENS + 1_000)
+  })
+
+  it('excludes replay metadata but counts reasoning and tool inputs', () => {
+    const message: ModelMessage = {
+      role: 'assistant',
+      content: [
+        {
+          type: 'reasoning',
+          text: 'x'.repeat(4_000),
+          providerOptions: { openai: { encryptedContent: 'a'.repeat(1_000_000) } },
+        },
+        { type: 'tool-call', toolCallId: 't1', toolName: 'write_file', input: { content: 'x'.repeat(40_000) } },
+      ],
+    }
+    expect(estimateModelMessageTokens(message)).toBeGreaterThan(11_000)
+    expect(estimateModelMessageTokens(message)).toBeLessThan(12_000)
+  })
+})

--- a/src/shared/models/context-message-tokens.ts
+++ b/src/shared/models/context-message-tokens.ts
@@ -1,0 +1,82 @@
+import type { ModelMessage } from 'ai'
+
+/**
+ * Pressure estimates, not billing/tokenizer counts. Binary payload length says
+ * nothing about vision/audio/document tokens, so use a bounded allowance per
+ * media part until the provider supplies a model-specific estimate.
+ */
+export const MEDIA_PART_ESTIMATE_TOKENS = 4_096
+const CHARS_PER_TOKEN = 4
+const PART_OVERHEAD_TOKENS = 8
+const MESSAGE_OVERHEAD_TOKENS = 4
+
+function textTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN)
+}
+
+function jsonTokens(value: unknown): number {
+  try {
+    return textTokens(JSON.stringify(value) ?? '')
+  } catch {
+    return 0
+  }
+}
+
+type ToolOutput = Extract<Extract<ModelMessage, { role: 'tool' }>['content'][number], { type: 'tool-result' }>['output']
+
+export function estimateToolOutputTokens(output: ToolOutput): number {
+  switch (output.type) {
+    case 'text':
+    case 'error-text':
+      return textTokens(output.value)
+    case 'json':
+    case 'error-json':
+      // Arbitrary JSON remains text on the wire. Only typed media parts may
+      // exclude their payload; never silently discount long tool-result text.
+      return jsonTokens(output.value)
+    case 'content':
+      return output.value.reduce(
+        (total, part) =>
+          total + PART_OVERHEAD_TOKENS + (part.type === 'text' ? textTokens(part.text) : MEDIA_PART_ESTIMATE_TOKENS),
+        0
+      )
+    default:
+      return PART_OVERHEAD_TOKENS
+  }
+}
+
+// Settled messages are immutable during one run. Do not serialize base64 or
+// Uint8Array data, nor provider replay metadata such as encrypted reasoning.
+const messageTokenCache = new WeakMap<object, number>()
+
+export function estimateModelMessageTokens(message: ModelMessage): number {
+  const cached = messageTokenCache.get(message)
+  if (cached !== undefined) return cached
+
+  let tokens = MESSAGE_OVERHEAD_TOKENS
+  if (typeof message.content === 'string') {
+    tokens += textTokens(message.content)
+  } else {
+    for (const part of message.content) {
+      tokens += PART_OVERHEAD_TOKENS
+      switch (part.type) {
+        case 'text':
+        case 'reasoning':
+          tokens += textTokens(part.text)
+          break
+        case 'image':
+        case 'file':
+          tokens += MEDIA_PART_ESTIMATE_TOKENS
+          break
+        case 'tool-call':
+          tokens += jsonTokens(part.input)
+          break
+        case 'tool-result':
+          tokens += estimateToolOutputTokens(part.output)
+          break
+      }
+    }
+  }
+  messageTokenCache.set(message, tokens)
+  return tokens
+}

--- a/src/shared/models/context-pressure-relief.test.ts
+++ b/src/shared/models/context-pressure-relief.test.ts
@@ -47,6 +47,48 @@ function outputOf(message: ModelMessage): { type: string; value?: unknown } {
 }
 
 describe('createMidRunToolResultRelief', () => {
+  it('does not clear tool history because a screenshot has a large base64 encoding', () => {
+    const relief = createMidRunToolResultRelief({ thresholdTokens: 814_400 })
+    const image: ModelMessage = {
+      role: 'user',
+      content: [{ type: 'image', image: 'A'.repeat(7_360_052), mediaType: 'image/png' }],
+    }
+    const messages = [image, assistantToolCall('t1'), toolResult('t1', 40_000)]
+    for (let i = 2; i <= 30; i++) {
+      messages.push(assistantToolCall(`t${i}`), toolResult(`t${i}`, 40_000))
+      expect(relief(messages)).toBeUndefined()
+    }
+    expect(outputOf(messages[2]).value).toBe('r'.repeat(40_000))
+  })
+
+  it('does not chase tool results when non-removable text alone exceeds the threshold', () => {
+    const relief = createMidRunToolResultRelief({ thresholdTokens: 10_000 })
+    const messages = [userMessage('x'.repeat(80_000)), assistantToolCall('t1'), toolResult('t1', 10_000)]
+    for (let i = 2; i <= 5; i++) {
+      messages.push(assistantToolCall(`t${i}`), toolResult(`t${i}`, 10_000))
+      expect(relief(messages)).toBeUndefined()
+    }
+  })
+
+  it('keeps its existing watermark stable if non-removable pressure later becomes dominant', () => {
+    const relief = createMidRunToolResultRelief({ thresholdTokens: 32_000 })
+    const base = [
+      userMessage('task'),
+      assistantToolCall('t1'),
+      toolResult('t1', 40_000),
+      assistantToolCall('t2'),
+      toolResult('t2', 40_000),
+      assistantToolCall('t3'),
+      toolResult('t3', 40_000),
+    ]
+    const first = relief(base) as ModelMessage[]
+    expect(outputOf(first[2]).value).toContain('cleared')
+    const grown = [...base, userMessage('x'.repeat(200_000)), assistantToolCall('t4'), toolResult('t4', 40_000)]
+    const second = relief(grown) as ModelMessage[]
+    expect(second.slice(0, base.length)).toEqual(first)
+    expect(outputOf(second[9]).value).toBe('r'.repeat(40_000))
+  })
+
   it('returns undefined while below the activation threshold', () => {
     const relief = createMidRunToolResultRelief({ thresholdTokens: 1_000_000 })
     const messages = [userMessage('hi'), assistantToolCall('t1'), toolResult('t1', 5000)]
@@ -166,7 +208,7 @@ describe('createMidRunToolResultRelief', () => {
   })
 
   it('never rewrites error outputs', () => {
-    const relief = createMidRunToolResultRelief({ thresholdTokens: 100 })
+    const relief = createMidRunToolResultRelief({ thresholdTokens: 10_000 })
     const messages = [
       userMessage('task'),
       assistantToolCall('t1'),

--- a/src/shared/models/context-pressure-relief.ts
+++ b/src/shared/models/context-pressure-relief.ts
@@ -1,38 +1,15 @@
 import type { ModelMessage } from 'ai'
+import { estimateModelMessageTokens, estimateToolOutputTokens } from './context-message-tokens'
 
 /** In-run relief activates at this fraction of the compaction threshold. */
 export const MID_RUN_RELIEF_ACTIVATION_RATIO = 0.9
 /** How many of the most recent tool-result messages stay intact when relieving. */
 export const MID_RUN_KEEP_RECENT_TOOL_MESSAGES = 2
 /** Outputs smaller than this are not worth rewriting (mutation without meaningful savings). */
-const MIN_STUB_OUTPUT_CHARS = 400
-/** chars-per-token heuristic; matches the estimation used for the compaction threshold. */
-const CHARS_PER_TOKEN = 4
-const PER_MESSAGE_OVERHEAD_TOKENS = 4
+const MIN_STUB_OUTPUT_TOKENS = 100
 
 const TOOL_RESULT_STUB_TEXT =
   '[Old tool result cleared to save context space. Call the tool again if this result is needed.]'
-
-// Step messages accumulate append-only within one run; earlier message objects
-// keep their identity across steps, so identity-keyed memoization avoids
-// re-serializing the whole transcript on every step.
-const messageTokenCache = new WeakMap<object, number>()
-
-function estimateModelMessageTokens(message: ModelMessage): number {
-  const cached = messageTokenCache.get(message)
-  if (cached !== undefined) {
-    return cached
-  }
-  let chars = 0
-  try {
-    chars = JSON.stringify(message.content)?.length ?? 0
-  } catch {
-    chars = 0
-  }
-  const tokens = Math.ceil(chars / CHARS_PER_TOKEN) + PER_MESSAGE_OVERHEAD_TOKENS
-  messageTokenCache.set(message, tokens)
-  return tokens
-}
 
 type ToolMessage = Extract<ModelMessage, { role: 'tool' }>
 type ToolResultItem = Extract<ToolMessage['content'][number], { type: 'tool-result' }>
@@ -43,31 +20,28 @@ function isStubbableOutput(output: ToolOutput): boolean {
   return output.type === 'text' || output.type === 'json' || output.type === 'content'
 }
 
-function serializedOutputLength(output: ToolOutput): number {
-  try {
-    return JSON.stringify(output)?.length ?? 0
-  } catch {
-    return 0
-  }
-}
+const stubbedMessageCache = new WeakMap<ToolMessage, { message: ToolMessage; savedTokens: number }>()
+const STUB_OUTPUT: ToolOutput = { type: 'text', value: TOOL_RESULT_STUB_TEXT }
+const STUB_OUTPUT_TOKENS = estimateToolOutputTokens(STUB_OUTPUT)
 
-function stubToolMessage(message: ToolMessage): { message: ToolMessage; savedChars: number } {
-  let savedChars = 0
+function stubToolMessage(message: ToolMessage): { message: ToolMessage; savedTokens: number } {
+  const cached = stubbedMessageCache.get(message)
+  if (cached) return cached
+  let savedTokens = 0
   const content = message.content.map((part) => {
     if (part.type !== 'tool-result' || !isStubbableOutput(part.output)) {
       return part
     }
-    const originalLength = serializedOutputLength(part.output)
-    if (originalLength <= MIN_STUB_OUTPUT_CHARS) {
+    const originalTokens = estimateToolOutputTokens(part.output)
+    if (originalTokens <= MIN_STUB_OUTPUT_TOKENS) {
       return part
     }
-    savedChars += originalLength - TOOL_RESULT_STUB_TEXT.length
-    return { ...part, output: { type: 'text' as const, value: TOOL_RESULT_STUB_TEXT } }
+    savedTokens += originalTokens - STUB_OUTPUT_TOKENS
+    return { ...part, output: STUB_OUTPUT }
   })
-  if (savedChars === 0) {
-    return { message, savedChars: 0 }
-  }
-  return { message: { ...message, content }, savedChars }
+  const result = { message: savedTokens === 0 ? message : { ...message, content }, savedTokens }
+  stubbedMessageCache.set(message, result)
+  return result
 }
 
 export interface MidRunToolResultReliefOptions {
@@ -119,22 +93,22 @@ export function createMidRunToolResultRelief(
       if (stubbedUpTo === 0) {
         return { messages, savedTokens: 0, changed: false }
       }
-      let savedChars = 0
+      let savedTokens = 0
       let changed = false
       const next = messages.map((message, index) => {
         if (index >= stubbedUpTo || message.role !== 'tool') {
           return message
         }
         const stubbed = stubToolMessage(message)
-        if (stubbed.savedChars > 0) {
-          savedChars += stubbed.savedChars
+        if (stubbed.savedTokens > 0) {
+          savedTokens += stubbed.savedTokens
           changed = true
         }
         return stubbed.message
       })
       return {
         messages: changed ? next : messages,
-        savedTokens: Math.floor(savedChars / CHARS_PER_TOKEN),
+        savedTokens,
         changed,
       }
     }
@@ -157,6 +131,21 @@ export function createMidRunToolResultRelief(
     }
 
     let applied = applyWatermark()
+    if (rawTokens - applied.savedTokens < activationTokens) {
+      return applied.changed ? applied.messages : undefined
+    }
+
+    // If even removing every eligible result cannot relieve the pressure,
+    // advancing the watermark only destroys useful history and the cached
+    // prefix. Preserve any existing watermark, but do not chase a moving tail
+    // because of oversized user text, media, tool inputs, or error outputs.
+    const possibleSavings = messages.reduce(
+      (total, message) => total + (message.role === 'tool' ? stubToolMessage(message).savedTokens : 0),
+      0
+    )
+    if (rawTokens - possibleSavings >= activationTokens) {
+      return applied.changed ? applied.messages : undefined
+    }
 
     // Ratchet: stub everything older than the protected tail; while still over
     // the activation threshold, shrink the tail (down to the floor of 1) so a

--- a/src/shared/providers/definitions/chatboxai.ts
+++ b/src/shared/providers/definitions/chatboxai.ts
@@ -23,6 +23,7 @@ export const chatboxAIProvider = defineProvider({
         topP: config.settings.topP,
         maxOutputTokens: config.settings.maxTokens,
         stream: config.settings.stream,
+        anthropicCacheTtl: config.globalSettings.anthropicCacheTtl,
       },
       config.config,
       config.dependencies

--- a/src/shared/providers/definitions/claude.ts
+++ b/src/shared/providers/definitions/claude.ts
@@ -105,6 +105,7 @@ export const claudeProvider = defineProvider({
         topP: config.settings.topP,
         maxOutputTokens: config.settings.maxTokens,
         stream: config.settings.stream,
+        anthropicCacheTtl: config.globalSettings.anthropicCacheTtl,
         extraHeaders: oauthHeaders,
         customFetch:
           isOAuth && credentialManager ? createBearerOAuthFetch(config.dependencies, credentialManager) : undefined,

--- a/src/shared/providers/definitions/models/chatboxai.ts
+++ b/src/shared/providers/definitions/models/chatboxai.ts
@@ -10,7 +10,7 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { type ModelMessage, streamText, type ToolSet } from 'ai'
 import { getRegistryModelMeta } from '../../../model-registry'
 import AbstractAISDKModel, { type CallSettings } from '../../../models/abstract-ai-sdk'
-import { addAnthropicCacheControl } from '../../../models/anthropic-cache'
+import { type AnthropicCacheTtl, addAnthropicCacheControl } from '../../../models/anthropic-cache'
 import { getOpenAICompatibleProviderOptionsKey } from '../../../models/openai-compatible'
 import type {
   CallChatCompletionOptions,
@@ -49,6 +49,7 @@ interface Options {
   topP?: number
   maxOutputTokens?: number
   stream?: boolean
+  anthropicCacheTtl?: AnthropicCacheTtl
 }
 
 interface Config {
@@ -443,7 +444,10 @@ export default class ChatboxAI extends AbstractAISDKModel implements ModelInterf
   }
 
   public async chat(messages: ModelMessage[], options: CallChatCompletionOptions): Promise<StreamTextResult> {
-    const cached = this.options.model.apiStyle === 'anthropic' ? addAnthropicCacheControl(messages) : messages
+    const cached =
+      this.options.model.apiStyle === 'anthropic'
+        ? addAnthropicCacheControl(messages, this.options.anthropicCacheTtl)
+        : messages
     return super.chat(cached, options)
   }
 
@@ -451,7 +455,10 @@ export default class ChatboxAI extends AbstractAISDKModel implements ModelInterf
     messages: ModelMessage[],
     options: ChatStreamOptions
   ): AsyncGenerator<ModelStreamPart<T>> {
-    const cached = this.options.model.apiStyle === 'anthropic' ? addAnthropicCacheControl(messages) : messages
+    const cached =
+      this.options.model.apiStyle === 'anthropic'
+        ? addAnthropicCacheControl(messages, this.options.anthropicCacheTtl)
+        : messages
     yield* super.chatStream<T>(cached, options)
   }
 

--- a/src/shared/providers/definitions/models/claude.ts
+++ b/src/shared/providers/definitions/models/claude.ts
@@ -1,7 +1,7 @@
 import { createAnthropic } from '@ai-sdk/anthropic'
 import type { ModelMessage, ToolSet } from 'ai'
 import AbstractAISDKModel, { type CallSettings } from '../../../models/abstract-ai-sdk'
-import { addAnthropicCacheControl } from '../../../models/anthropic-cache'
+import { type AnthropicCacheTtl, addAnthropicCacheControl } from '../../../models/anthropic-cache'
 import { ApiError } from '../../../models/errors'
 import type { CallChatCompletionOptions, ChatStreamOptions, ModelStreamPart } from '../../../models/types'
 import type { ProviderModelInfo, StreamTextResult } from '../../../types'
@@ -17,6 +17,7 @@ interface Options {
   topP?: number
   maxOutputTokens?: number
   stream?: boolean
+  anthropicCacheTtl?: AnthropicCacheTtl
   extraHeaders?: Record<string, string>
   customFetch?: typeof globalThis.fetch
   authToken?: string
@@ -132,14 +133,14 @@ export default class Claude extends AbstractAISDKModel {
   }
 
   public async chat(messages: ModelMessage[], options: CallChatCompletionOptions): Promise<StreamTextResult> {
-    return super.chat(addAnthropicCacheControl(messages), options)
+    return super.chat(addAnthropicCacheControl(messages, this.options.anthropicCacheTtl), options)
   }
 
   public async *chatStream<T extends ToolSet>(
     messages: ModelMessage[],
     options: ChatStreamOptions
   ): AsyncGenerator<ModelStreamPart<T>> {
-    yield* super.chatStream<T>(addAnthropicCacheControl(messages), options)
+    yield* super.chatStream<T>(addAnthropicCacheControl(messages, this.options.anthropicCacheTtl), options)
   }
 
   // https://docs.anthropic.com/en/docs/api/models

--- a/src/shared/providers/definitions/models/custom-claude.ts
+++ b/src/shared/providers/definitions/models/custom-claude.ts
@@ -2,7 +2,7 @@ import { createAnthropic } from '@ai-sdk/anthropic'
 import type { LanguageModelV3 } from '@ai-sdk/provider'
 import type { ModelMessage, ToolSet } from 'ai'
 import AbstractAISDKModel, { type CallSettings } from '../../../models/abstract-ai-sdk'
-import { addAnthropicCacheControl } from '../../../models/anthropic-cache'
+import { type AnthropicCacheTtl, addAnthropicCacheControl } from '../../../models/anthropic-cache'
 import { ApiError } from '../../../models/errors'
 import type { CallChatCompletionOptions, ChatStreamOptions, ModelStreamPart } from '../../../models/types'
 import { createFetchWithProxy } from '../../../models/utils/fetch-proxy'
@@ -19,6 +19,7 @@ interface Options {
   topP?: number
   maxOutputTokens?: number
   stream?: boolean
+  anthropicCacheTtl?: AnthropicCacheTtl
   useProxy?: boolean
 }
 
@@ -77,14 +78,14 @@ export default class CustomClaude extends AbstractAISDKModel {
   }
 
   public async chat(messages: ModelMessage[], options: CallChatCompletionOptions): Promise<StreamTextResult> {
-    return super.chat(addAnthropicCacheControl(messages), options)
+    return super.chat(addAnthropicCacheControl(messages, this.options.anthropicCacheTtl), options)
   }
 
   public async *chatStream<T extends ToolSet>(
     messages: ModelMessage[],
     options: ChatStreamOptions
   ): AsyncGenerator<ModelStreamPart<T>> {
-    yield* super.chatStream<T>(addAnthropicCacheControl(messages), options)
+    yield* super.chatStream<T>(addAnthropicCacheControl(messages, this.options.anthropicCacheTtl), options)
   }
 
   public async listModels(): Promise<ProviderModelInfo[]> {

--- a/src/shared/providers/utils.ts
+++ b/src/shared/providers/utils.ts
@@ -18,6 +18,7 @@ export function createCustomProviderModel(
     case ModelProviderType.Claude:
       return new CustomClaude(
         {
+          anthropicCacheTtl: config.globalSettings.anthropicCacheTtl,
           apiKey: config.effectiveApiKey,
           apiHost: formattedApiHost,
           model,


### PR DESCRIPTION
### Description

Fix false mid-run context pressure caused by treating encoded media as text, and add configurable Anthropic prompt-cache retention.

#### Context pressure and cache stability

The previous estimator used `JSON.stringify(message.content).length / 4`. A large base64 screenshot could therefore account for hundreds of thousands of estimated tokens. Since tool-result relief does not remove user images, pressure could remain above the threshold after cleanup and repeatedly advance the cleanup boundary, rewriting previously sent history and reducing prompt-cache reuse.

- Estimate text, reasoning and tool inputs/results separately from typed image/file content.
- Use a bounded 4,096-token allowance per media part rather than its base64 or binary byte length. This is a pressure heuristic, not a provider-specific token count.
- Use the same estimator for tool-output savings.
- Preserve the existing cleanup watermark when non-removable content alone exceeds the threshold, rather than repeatedly discarding more results without resolving the pressure.
- Keep normal text/JSON tool results fully accounted for and preserve error outputs and the newest tool result.

#### Anthropic cache TTL

- Add **Anthropic prompt cache duration** under **Chat Settings → Context Management**: **5 minutes (default)** or **1 hour**.
- Persist and validate the global `anthropicCacheTtl` setting, with backward-compatible `5m` defaults.
- Pass the setting through Claude API, custom Anthropic providers and Anthropic-routed Chatbox AI models, for both streaming and non-streaming requests.
- Send `cache_control: { type: "ephemeral", ttl: "1h" }` when selected; omit the default TTL for compatibility with existing relays.
- Add English/Russian UI copy explaining the higher one-hour cache-write price and provider/proxy support requirement.

### Additional Notes

Validation completed:

- **33 targeted tests passed** across five suites: multimodal estimates, relief/prefix stability, cache breakpoints, settings persistence/defaults, and mocked Anthropic SDK wire serialization in streaming/non-streaming modes.
- Targeted TypeScript checking: no diagnostics.
- Biome checks: no errors; `git diff --check`: clean.
- Production main/preload/renderer build and Linux x86_64 AppImage packaging succeeded; packaged renderer was checked for the estimator and TTL setting. The AppImage was not launched as part of validation.
- Offline replay of four affected saved agent runs no longer triggered false result clearing or cleanup-driven prefix rewrites. No conversation data or replay fixtures are included in this PR.

This change does not change Anthropic breakpoint placement within the agent loop, implement provider-specific media tokenization, or add Bedrock cache settings. One-hour retention does not prevent cache misses caused by changing the prompt prefix.

### Screenshots

Not included.

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

- [x] I have read and agree with the above statement.
