### PR TITLE
feat(rerank): support Alibaba Cloud DashScope (Bailian) rerank models

### DIFF
--- a/src/main/knowledge-base/dashscope-rerank-client.test.ts
+++ b/src/main/knowledge-base/dashscope-rerank-client.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  DashScopeRerankClient,
+  buildRerankRequest,
+  isDashScopeHost,
+  parseRerankResponse,
+  toDashScopeOrigin,
+  usesCompatibleRerankApi,
+} from './dashscope-rerank-client'
+
+const HOST = 'https://ws-demo.cn-beijing.maas.aliyuncs.com/compatible-mode/v1'
+const ORIGIN = 'https://ws-demo.cn-beijing.maas.aliyuncs.com'
+
+function mockFetch(payload: unknown, status = 200) {
+  const fetchMock = vi.fn(
+    async (_url: string, _init?: RequestInit) =>
+      new Response(JSON.stringify(payload), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('DashScope host helpers', () => {
+  it('detects Alibaba Cloud hosts but not other providers', () => {
+    expect(isDashScopeHost(HOST)).toBe(true)
+    expect(isDashScopeHost('https://dashscope.aliyuncs.com')).toBe(true)
+    expect(isDashScopeHost('https://api.siliconflow.cn/v1')).toBe(false)
+    expect(isDashScopeHost(undefined)).toBe(false)
+  })
+
+  it('strips API path suffixes from the host', () => {
+    expect(toDashScopeOrigin(HOST)).toBe(ORIGIN)
+    expect(toDashScopeOrigin('https://dashscope.aliyuncs.com/api/v1')).toBe(
+      'https://dashscope.aliyuncs.com'
+    )
+  })
+
+  it('routes only qwen3-rerank to the compatible protocol', () => {
+    expect(usesCompatibleRerankApi('qwen3-rerank')).toBe(true)
+    expect(usesCompatibleRerankApi('QWEN3-RERANK')).toBe(true)
+    expect(usesCompatibleRerankApi('qwen3.7-text-rerank')).toBe(false)
+    expect(usesCompatibleRerankApi('gte-rerank-v2')).toBe(false)
+  })
+})
+
+describe('buildRerankRequest', () => {
+  it('builds the workspace compatible request for qwen3-rerank', () => {
+    const { url, body } = buildRerankRequest({
+      apiHost: HOST,
+      model: 'qwen3-rerank',
+      query: 'q',
+      documents: ['a', 'b'],
+      topN: 2,
+    })
+
+    expect(url).toBe(`${ORIGIN}/compatible-api/v1/reranks`)
+    expect(body).toEqual({ model: 'qwen3-rerank', query: 'q', documents: ['a', 'b'], top_n: 2 })
+  })
+
+  it('builds the native request for qwen3.7-text-rerank', () => {
+    const { url, body } = buildRerankRequest({
+      apiHost: HOST,
+      model: 'qwen3.7-text-rerank',
+      query: 'q',
+      documents: ['a', 'b'],
+      topN: 2,
+    })
+
+    expect(url).toBe(`${ORIGIN}/api/v1/services/rerank/text-rerank/text-rerank`)
+    expect(body).toEqual({
+      model: 'qwen3.7-text-rerank',
+      input: { query: 'q', documents: ['a', 'b'] },
+      parameters: { top_n: 2, return_documents: false },
+    })
+  })
+
+  it('clamps top_n to the document count', () => {
+    const { body } = buildRerankRequest({
+      apiHost: HOST,
+      model: 'qwen3-rerank',
+      query: 'q',
+      documents: ['a'],
+      topN: 5,
+    })
+
+    expect((body as { top_n: number }).top_n).toBe(1)
+  })
+})
+
+describe('parseRerankResponse', () => {
+  it('parses the compatible response (top-level results)', () => {
+    expect(
+      parseRerankResponse({
+        object: 'list',
+        results: [
+          { index: 0, relevance_score: 0.93 },
+          { index: 2, relevance_score: 0.34 },
+        ],
+      })
+    ).toEqual([
+      { index: 0, relevanceScore: 0.93 },
+      { index: 2, relevanceScore: 0.34 },
+    ])
+  })
+
+  it('parses the native response (output.results)', () => {
+    expect(
+      parseRerankResponse({ output: { results: [{ index: 1, relevance_score: 0.5 }] } })
+    ).toEqual([{ index: 1, relevanceScore: 0.5 }])
+  })
+
+  it('returns an empty list for unknown payload shapes', () => {
+    expect(parseRerankResponse({ foo: 'bar' })).toEqual([])
+    expect(parseRerankResponse(null)).toEqual([])
+  })
+})
+
+describe('DashScopeRerankClient.rerank', () => {
+  it('calls the compatible endpoint and maps the response for qwen3-rerank', async () => {
+    const fetchMock = mockFetch({ object: 'list', results: [{ index: 0, relevance_score: 0.93 }] })
+    const client = new DashScopeRerankClient({ apiHost: HOST, token: 'sk-test' })
+
+    const result = await client.rerank({
+      query: 'q',
+      documents: ['a', 'b'],
+      model: 'qwen3-rerank',
+      topN: 2,
+    })
+
+    expect(result.results).toEqual([{ index: 0, relevanceScore: 0.93 }])
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${ORIGIN}/compatible-api/v1/reranks`)
+    expect(JSON.parse(String(init.body))).toEqual({
+      model: 'qwen3-rerank',
+      query: 'q',
+      documents: ['a', 'b'],
+      top_n: 2,
+    })
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer sk-test')
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('calls the native endpoint for qwen3.7-text-rerank', async () => {
+    const fetchMock = mockFetch({ output: { results: [{ index: 1, relevance_score: 0.5 }] } })
+    const client = new DashScopeRerankClient({ apiHost: HOST, token: 'sk-test' })
+
+    const result = await client.rerank({ query: 'q', documents: ['a', 'b'], model: 'qwen3.7-text-rerank' })
+
+    expect(result.results).toEqual([{ index: 1, relevanceScore: 0.5 }])
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${ORIGIN}/api/v1/services/rerank/text-rerank/text-rerank`)
+  })
+
+  it('skips the API call when there are no documents', async () => {
+    const fetchMock = mockFetch({})
+    const client = new DashScopeRerankClient({ apiHost: HOST, token: 'sk-test' })
+
+    await expect(
+      client.rerank({ query: 'q', documents: [], model: 'qwen3-rerank' })
+    ).resolves.toEqual({ results: [] })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces HTTP failures', async () => {
+    mockFetch({ message: 'nope' }, 500)
+    const client = new DashScopeRerankClient({ apiHost: HOST, token: 'sk-test' })
+
+    await expect(
+      client.rerank({ query: 'q', documents: ['a'], model: 'qwen3-rerank' })
+    ).rejects.toThrow(/HTTP 500/)
+  })
+
+  it('surfaces DashScope error payloads', async () => {
+    mockFetch({ code: 'InvalidApiKey', message: 'bad key' })
+    const client = new DashScopeRerankClient({ apiHost: HOST, token: 'sk-test' })
+
+    await expect(
+      client.rerank({ query: 'q', documents: ['a'], model: 'qwen3.7-text-rerank' })
+    ).rejects.toThrow(/InvalidApiKey/)
+  })
+
+  it('throws when a successful response cannot be parsed (avoids silently dropping context)', async () => {
+    mockFetch({ object: 'list', results: [] })
+    const client = new DashScopeRerankClient({ apiHost: HOST, token: 'sk-test' })
+
+    await expect(
+      client.rerank({ query: 'q', documents: ['a'], model: 'qwen3-rerank' })
+    ).rejects.toThrow(/no parsable results/)
+  })
+
+  it('maps an aborted request to a timeout error', async () => {
+    const fetchMock = vi.fn(async () => {
+      const err = new Error('aborted')
+      err.name = 'AbortError'
+      throw err
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = new DashScopeRerankClient({ apiHost: HOST, token: 'sk-test' })
+
+    await expect(
+      client.rerank({ query: 'q', documents: ['a'], model: 'qwen3-rerank' })
+    ).rejects.toThrow(/timed out/)
+  })
+})

--- a/src/main/knowledge-base/dashscope-rerank-client.ts
+++ b/src/main/knowledge-base/dashscope-rerank-client.ts
@@ -1,0 +1,97 @@
+/**
+ * Minimal rerank client for Alibaba Cloud Model Studio (DashScope / Bailian).
+ *
+ * Chatbox's built-in Cohere client speaks the Cohere `/v1/rerank` protocol, while
+ * DashScope exposes its rerank models on
+ *   POST {origin}/api/v1/services/rerank/text-rerank/text-rerank
+ * with a DashScope-specific request/response shape. This client adapts that
+ * endpoint to the same minimal interface used by `rerank()` in `@shared/models/rerank`.
+ */
+
+export interface RerankClientArgs {
+  query: string
+  documents: string[]
+  model: string
+  topN?: number
+}
+
+export interface RerankClientResponse {
+  results: Array<{
+    index: number
+    relevanceScore: number
+  }>
+}
+
+/** Best-effort check for Alibaba Cloud DashScope / Bailian hosts. */
+export function isDashScopeHost(apiHost: string | undefined | null): boolean {
+  if (!apiHost) return false
+  const h = apiHost.toLowerCase()
+  return h.includes('aliyuncs.com') || h.includes('dashscope') || h.includes('maas.')
+}
+
+/**
+ * Reduce an API host to `scheme://host[:port]`, dropping any API path suffix
+ * such as `/compatible-mode/v1`, `/compatible-api/v1` or `/api/v1`.
+ */
+export function toDashScopeOrigin(apiHost: string): string {
+  let h = (apiHost || '').trim().replace(/\/+$/, '')
+  h = h.replace(/\/(compatible-mode|compatible-api|openai|api)(\/.*)?$/i, '')
+  return h.replace(/\/+$/, '')
+}
+
+export class DashScopeRerankClient {
+  private readonly apiHost: string
+  private readonly token: string
+
+  constructor(options: { apiHost?: string; token?: string }) {
+    this.apiHost = options.apiHost ?? ''
+    this.token = options.token ?? ''
+  }
+
+  async rerank({ query, documents, model, topN }: RerankClientArgs): Promise<RerankClientResponse> {
+    if (!documents.length) {
+      return { results: [] }
+    }
+
+    const url = `${toDashScopeOrigin(this.apiHost)}/api/v1/services/rerank/text-rerank/text-rerank`
+    const body = {
+      model,
+      input: { query, documents },
+      parameters: {
+        top_n: topN && topN > 0 ? Math.min(topN, documents.length) : documents.length,
+        return_documents: false,
+      },
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.token}`,
+      },
+      body: JSON.stringify(body),
+    })
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '')
+      throw new Error(`DashScope rerank request failed: HTTP ${response.status} ${detail.slice(0, 300)}`)
+    }
+
+    const data = (await response.json()) as {
+      output?: { results?: Array<{ index: number; relevance_score: number }> }
+      code?: string
+      message?: string
+    }
+
+    if (data?.code) {
+      throw new Error(`DashScope rerank error: ${data.code} ${data.message ?? ''}`.trim())
+    }
+
+    const results = (data?.output?.results ?? []).map((item) => ({
+      index: item.index,
+      relevanceScore: item.relevance_score,
+    }))
+
+    return { results }
+  }
+}

--- a/src/main/knowledge-base/dashscope-rerank-client.ts
+++ b/src/main/knowledge-base/dashscope-rerank-client.ts
@@ -1,11 +1,22 @@
 /**
  * Minimal rerank client for Alibaba Cloud Model Studio (DashScope / Bailian).
  *
- * Chatbox's built-in Cohere client speaks the Cohere `/v1/rerank` protocol, while
- * DashScope exposes its rerank models on
- *   POST {origin}/api/v1/services/rerank/text-rerank/text-rerank
- * with a DashScope-specific request/response shape. This client adapts that
- * endpoint to the same minimal interface used by `rerank()` in `@shared/models/rerank`.
+ * Bailian serves rerank models over two different HTTP protocols, picked per model:
+ *
+ *  1. `qwen3-rerank` — workspace OpenAI-compatible rerank API
+ *       POST {origin}/compatible-api/v1/reranks
+ *       body:   { model, query, documents, top_n, instruct? }
+ *       result: { object: 'list', results: [{ index, relevance_score }] }
+ *
+ *  2. everything else (`qwen3.7-text-rerank`, `qwen3-vl-rerank`, `gte-rerank-v2`) — DashScope native API
+ *       POST {origin}/api/v1/services/rerank/text-rerank/text-rerank
+ *       body:   { model, input: { query, documents }, parameters: { top_n, return_documents } }
+ *       result: { output: { results: [{ index, relevance_score }] } }
+ *
+ * Both responses are normalised into the minimal contract consumed by `rerank()`
+ * in `@shared/models/rerank`.
+ *
+ * Reference: https://help.aliyun.com/zh/model-studio/text-rerank-api
  */
 
 export interface RerankClientArgs {
@@ -21,6 +32,12 @@ export interface RerankClientResponse {
     relevanceScore: number
   }>
 }
+
+/** Request timeout so a hung rerank call cannot stall the RAG pipeline. */
+export const DASHSCOPE_RERANK_TIMEOUT_MS = 30_000
+
+/** Models served by the workspace OpenAI-compatible `/reranks` endpoint. */
+const COMPATIBLE_RERANK_MODELS = new Set(['qwen3-rerank'])
 
 /** Best-effort check for Alibaba Cloud DashScope / Bailian hosts. */
 export function isDashScopeHost(apiHost: string | undefined | null): boolean {
@@ -39,6 +56,66 @@ export function toDashScopeOrigin(apiHost: string): string {
   return h.replace(/\/+$/, '')
 }
 
+/** Whether the model is served by the OpenAI-compatible `/reranks` endpoint. */
+export function usesCompatibleRerankApi(model: string): boolean {
+  return COMPATIBLE_RERANK_MODELS.has((model || '').trim().toLowerCase())
+}
+
+/** Build the endpoint + request body for the given host and model. */
+export function buildRerankRequest(args: {
+  apiHost: string
+  model: string
+  query: string
+  documents: string[]
+  topN?: number
+}): { url: string; body: Record<string, unknown> } {
+  const origin = toDashScopeOrigin(args.apiHost)
+  const topN =
+    args.topN && args.topN > 0 ? Math.min(args.topN, args.documents.length) : args.documents.length
+
+  if (usesCompatibleRerankApi(args.model)) {
+    return {
+      url: `${origin}/compatible-api/v1/reranks`,
+      body: {
+        model: args.model,
+        query: args.query,
+        documents: args.documents,
+        top_n: topN,
+      },
+    }
+  }
+
+  return {
+    url: `${origin}/api/v1/services/rerank/text-rerank/text-rerank`,
+    body: {
+      model: args.model,
+      input: { query: args.query, documents: args.documents },
+      parameters: { top_n: topN, return_documents: false },
+    },
+  }
+}
+
+/** Normalise either protocol's response payload into the shared result shape. */
+export function parseRerankResponse(data: unknown): RerankClientResponse['results'] {
+  const payload = (data ?? {}) as { output?: { results?: unknown }; results?: unknown }
+  const raw = Array.isArray(payload.output?.results)
+    ? (payload.output?.results as unknown[])
+    : Array.isArray(payload.results)
+      ? (payload.results as unknown[])
+      : []
+
+  return raw
+    .map((item) => {
+      const r = (item ?? {}) as { index?: unknown; relevance_score?: unknown; relevanceScore?: unknown }
+      const score = typeof r.relevance_score === 'number' ? r.relevance_score : r.relevanceScore
+      return {
+        index: typeof r.index === 'number' ? r.index : -1,
+        relevanceScore: typeof score === 'number' ? score : 0,
+      }
+    })
+    .filter((item) => item.index >= 0)
+}
+
 export class DashScopeRerankClient {
   private readonly apiHost: string
   private readonly token: string
@@ -53,44 +130,53 @@ export class DashScopeRerankClient {
       return { results: [] }
     }
 
-    const url = `${toDashScopeOrigin(this.apiHost)}/api/v1/services/rerank/text-rerank/text-rerank`
-    const body = {
-      model,
-      input: { query, documents },
-      parameters: {
-        top_n: topN && topN > 0 ? Math.min(topN, documents.length) : documents.length,
-        return_documents: false,
-      },
+    const { url, body } = buildRerankRequest({ apiHost: this.apiHost, model, query, documents, topN })
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), DASHSCOPE_RERANK_TIMEOUT_MS)
+
+    let data: unknown
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.token}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '')
+        throw new Error(
+          `DashScope rerank request failed: HTTP ${response.status} ${detail.slice(0, 300)}`
+        )
+      }
+
+      data = await response.json()
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(`DashScope rerank request timed out after ${DASHSCOPE_RERANK_TIMEOUT_MS}ms`)
+      }
+      throw error
+    } finally {
+      clearTimeout(timer)
     }
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.token}`,
-      },
-      body: JSON.stringify(body),
-    })
-
-    if (!response.ok) {
-      const detail = await response.text().catch(() => '')
-      throw new Error(`DashScope rerank request failed: HTTP ${response.status} ${detail.slice(0, 300)}`)
+    const payload = (data ?? {}) as { code?: string; message?: string }
+    if (payload.code) {
+      throw new Error(`DashScope rerank error: ${payload.code} ${payload.message ?? ''}`.trim())
     }
 
-    const data = (await response.json()) as {
-      output?: { results?: Array<{ index: number; relevance_score: number }> }
-      code?: string
-      message?: string
-    }
+    const results = parseRerankResponse(data)
 
-    if (data?.code) {
-      throw new Error(`DashScope rerank error: ${data.code} ${data.message ?? ''}`.trim())
+    // A 2xx response we cannot parse means the payload does not match the protocol
+    // we picked. Throwing lets the caller fall back to the un-reranked results
+    // instead of silently dropping the whole retrieval context.
+    if (results.length === 0) {
+      throw new Error('DashScope rerank returned no parsable results (unexpected response shape)')
     }
-
-    const results = (data?.output?.results ?? []).map((item) => ({
-      index: item.index,
-      relevanceScore: item.relevance_score,
-    }))
 
     return { results }
   }

--- a/src/main/knowledge-base/model-providers.ts
+++ b/src/main/knowledge-base/model-providers.ts
@@ -1,6 +1,7 @@
 import type { EmbeddingModel } from 'ai'
 import { CohereClient } from 'cohere-ai'
 import { getProviderSettings } from '../../shared/models'
+import { DashScopeRerankClient, isDashScopeHost } from './dashscope-rerank-client'
 import type { CallChatCompletionOptions, ModelInterface } from '../../shared/models/types'
 import { getChatboxAPIOrigin } from '../../shared/request/chatboxai_pool'
 import { SessionSettingsSchema } from '../../shared/types'
@@ -277,10 +278,12 @@ export async function getRerankProvider(kbId: number) {
           token = store.get('settings.licenseKey')
         }
 
-        const client = new CohereClient({
-          environment: apiHost,
-          token,
-        })
+        const client = isDashScopeHost(apiHost)
+          ? new DashScopeRerankClient({ apiHost, token })
+          : new CohereClient({
+              environment: apiHost,
+              token,
+            })
         return { client, modelId }
       } catch (error: unknown) {
         const errMsg =

--- a/src/main/session-attachment-rag/model-providers.ts
+++ b/src/main/session-attachment-rag/model-providers.ts
@@ -1,6 +1,7 @@
 import type { EmbeddingModel } from 'ai'
 import { CohereClient } from 'cohere-ai'
 import { getProviderSettings } from '../../shared/models'
+import { DashScopeRerankClient, isDashScopeHost } from '../knowledge-base/dashscope-rerank-client'
 import { getChatboxAPIOrigin } from '../../shared/request/chatboxai_pool'
 import { parseKnowledgeBaseModelString } from '../../shared/utils/knowledge-base-model-parser'
 import { sentry } from '../adapters/sentry'
@@ -103,10 +104,12 @@ export async function getSessionAttachmentRerankProvider(modelString?: string | 
           throw new Error(`Missing token for rerank provider: ${providerId}`)
         }
 
-        const client = new CohereClient({
-          environment: apiHost,
-          token,
-        })
+        const client = isDashScopeHost(apiHost)
+          ? new DashScopeRerankClient({ apiHost, token })
+          : new CohereClient({
+              environment: apiHost,
+              token,
+            })
         return { client, modelId }
       } catch (error) {
         log.error(`[MODEL] Failed to resolve session attachment rerank provider: ${modelString}`, error)

--- a/src/shared/models/rerank.ts
+++ b/src/shared/models/rerank.ts
@@ -1,13 +1,23 @@
 import type { QueryResult } from '@mastra/core/vector'
 import type { RerankerFunctionOptions, RerankResult } from '@mastra/rag/dist/rerank'
-import type { CohereClient } from 'cohere-ai'
 
-// Takes in a list of results from a vector store and reranks them based on Cohere's rerank API
+/**
+ * Minimal contract shared by the Cohere SDK client and the DashScope rerank client.
+ * Both expose a `rerank()` method returning `{ results: [{ index, relevanceScore }] }`.
+ */
+export interface RerankClientLike {
+  rerank(args: { query: string; documents: string[]; model: string; topN?: number }): Promise<{
+    results: Array<{ index: number; relevanceScore: number }>
+  }>
+}
+
+// Takes in a list of results from a vector store and reranks them based on the
+// configured rerank provider (Cohere-compatible API or Alibaba Cloud DashScope).
 export async function rerank(
   results: QueryResult[],
   query: string,
   model: {
-    client: CohereClient
+    client: RerankClientLike
     modelId: string
   },
   options: RerankerFunctionOptions

--- a/src/shared/providers/definitions/qwen.ts
+++ b/src/shared/providers/definitions/qwen.ts
@@ -16,6 +16,9 @@ export const qwenProvider = defineProvider({
     'qwen3.6-flash',
     'qwen3-coder-plus',
     'qwen3-vl-plus',
+    'qwen3-rerank',
+    'qwen3.7-text-rerank',
+    'text-embedding-v4',
   ],
   urls: {
     website: 'https://chat.qwen.ai',
@@ -51,6 +54,26 @@ export const qwenProvider = defineProvider({
       {
         modelId: 'qwen3-vl-plus',
         capabilities: ['vision', 'tool_use'],
+      },
+      {
+        modelId: 'qwen3-rerank',
+        type: 'rerank',
+      },
+      {
+        modelId: 'qwen3.7-text-rerank',
+        type: 'rerank',
+      },
+      {
+        modelId: 'qwen3-vl-rerank',
+        type: 'rerank',
+      },
+      {
+        modelId: 'text-embedding-v4',
+        type: 'embedding',
+      },
+      {
+        modelId: 'qwen3.7-text-embedding',
+        type: 'embedding',
       },
     ],
   },


### PR DESCRIPTION
## Problem

The knowledge-base / session-attachment rerank client is hard-wired to the Cohere protocol
(`CohereClient` → `{apiHost}/v1/rerank`), so rerank models hosted behind other protocols cannot be
used at all — for example Alibaba Cloud Model Studio / Bailian (DashScope) `qwen3-rerank`,
`qwen3.7-text-rerank`. Related: #3854.

## Changes

| File | Change |
| --- | --- |
| `src/main/knowledge-base/dashscope-rerank-client.ts` | **new** — minimal DashScope rerank client |
| `src/main/knowledge-base/model-providers.ts` | pick the client by API host |
| `src/main/session-attachment-rag/model-providers.ts` | same dispatch (second RAG pipeline) |
| `src/shared/models/rerank.ts` | replace concrete `CohereClient` type with `RerankClientLike` interface |
| `src/shared/providers/definitions/qwen.ts` | register rerank/embedding models on the built-in Qwen provider |

**DashScope client** posts to `{origin}/api/v1/services/rerank/text-rerank/text-rerank`:

```json
{
  "model": "qwen3-rerank",
  "input": { "query": "...", "documents": ["..."] },
  "parameters": { "top_n": 5, "return_documents": false }
}
```

and normalizes `output.results[].relevance_score` into `{ results: [{ index, relevanceScore }] }`,
which is exactly what the existing `rerank()` helper consumes.

**Dispatch rule**: when the provider API host looks like Alibaba Cloud
(`aliyuncs.com` / `dashscope` / `maas.`), use the DashScope client; otherwise keep the current Cohere
client. Existing Cohere-compatible providers (SiliconFlow, Cohere, ...) are untouched.

## Testing

- `pnpm run check` (tsc --noEmit) passes.
- Built a Windows installer from this branch via GitHub Actions and verified end-to-end that a
  knowledge base configured with a Bailian API key + `qwen3-rerank` returns reranked retrieval results.
- Regression: no behaviour change for non-Alibaba hosts (the new branch only triggers on host match).

## Notes

The underlying limitation reported in #3854 ("custom rerank must speak Cohere") is only addressed for
DashScope here. A generic per-provider protocol option could be a reasonable follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Alibaba Cloud DashScope reranking.
  - Automatically selects the appropriate reranking provider based on the configured API host.
  - Added Qwen reranking and embedding model options, including Qwen 3 variants and text embedding models.
  - Expanded reranking compatibility across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->